### PR TITLE
Driver Configuration options

### DIFF
--- a/fauna/client.py
+++ b/fauna/client.py
@@ -52,7 +52,7 @@ class Client:
         linearized: Optional[bool] = None,
         max_contention_retries: Optional[int] = None,
         query_timeout: Optional[timedelta] = None,
-        headers: Optional[Dict[str, str]] = None,
+        additional_headers: Optional[Dict[str, str]] = None,
     ):
 
         if endpoint is None:
@@ -91,10 +91,10 @@ class Client:
             self._headers[Header.MaxContentionRetries] = \
                 f"{max_contention_retries}"
 
-        if headers is not None:
+        if additional_headers is not None:
             self._headers = {
                 **self._headers,
-                **headers,
+                **additional_headers,
             }
 
         self._session: HTTPClient

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -223,7 +223,7 @@ def test_client_headers(
             expected = {"happy": "fox"}
             c = Client(
                 http_client=http_client,
-                headers=expected,
+                additional_headers=expected,
             )
             c.query(fql("just a mock"))
 


### PR DESCRIPTION
Ticket(s): BT-3463

## Problem

Consumer should be able to config Client/Query options

## Solution

- Validation tests for:
  - BT-3577 - Add support for Linearized
  - BT-3578 - Add support for Max Contention Retries
  - BT-3581 - Add support for Traceparent
  - BT-3585 - Add support for custom headers
- Fixed a few options that we're not setting the appropriate headers

## Result

Consumers can fully operate the driver as expected

## Testing

Tests added
