### PR TITLE
Iteratable response spike

### DIFF
--- a/fauna/client.py
+++ b/fauna/client.py
@@ -241,4 +241,4 @@ class Client:
                 x_txn_time = response.headers()[Header.TxnTime]
                 self.set_last_transaction_time(int(x_txn_time))
 
-        return Response(response)
+        return Response(self, response)

--- a/tests/integration/test_pagination.py
+++ b/tests/integration/test_pagination.py
@@ -1,0 +1,36 @@
+from fauna import fql
+
+
+def test_client_handles_pagination(client, a_collection):
+    q = fql('$col.create({ "foo": "bar" })', col=a_collection)
+
+    for _ in range(0, 100):
+        client.query(q)
+
+    q = fql('$col.all', col=a_collection)
+
+    data = client.query(q).data
+    total = len(data['data'])
+
+    while 'after' in data:
+        p = fql('Set.paginate($token)', token=data['after'])
+        data = client.query(p).data
+        total += len(data['data'])
+
+    assert total == 100
+
+
+def test_response_iterator(client, a_collection):
+    q = fql('$col.create({ "foo": "bar" })', col=a_collection)
+
+    for _ in range(0, 100):
+        client.query(q)
+
+    q = fql('$col.all', col=a_collection)
+    total = 0
+
+    for page in client.query(q).pages():
+        total += len(page.data['data'])
+
+    assert total == 100
+


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-###, FE-###,...

## Problem

Abstract pagination away from users

## Solution

Implement a response iterator and add Response.pages() to return it.


## Testing

You can see the difference in the tests.
