### PR TITLE
Bring template format inline with JS

### DIFF
--- a/fauna/template.py
+++ b/fauna/template.py
@@ -22,7 +22,7 @@ class FaunaTemplate:
         pattern = fr"""
         {delim}(?:
           (?P<escaped>{delim})  |   # Escape sequence of two delimiters
-          (?P<named>{self._idpattern})       |   # delimiter and a Python identifier
+          {{(?P<braced>{self._idpattern})}} |   # delimiter and a braced identifier
           (?P<invalid>)             # Other ill-formed delimiter exprs
         ) 
         """
@@ -49,7 +49,7 @@ class FaunaTemplate:
             span_start_pos = mo.span()[0]
             span_end_pos = mo.span()[1]
             escaped_part = mo.group("escaped") or ""
-            variable_part = mo.group("named")
+            variable_part = mo.group("braced")
             literal_part: Optional[str] = None
 
             if cur_pos != span_start_pos:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,5 @@
 import random
 import string
-from datetime import date, datetime
 
 import pytest
 
@@ -10,7 +9,7 @@ from fauna.models import Module
 
 
 def create_collection(name) -> QueryBuilder:
-    return fql('Collection.create({ name: $name})', name=name)
+    return fql('Collection.create({ name: ${name} })', name=name)
 
 
 @pytest.fixture

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -4,13 +4,13 @@ from fauna import Client, fql
 def test_client_tracks_last_txn_ts(a_collection):
     c = Client()
     assert c.get_last_transaction_time() is None
-    c.query(fql('$col.all', col=a_collection))
+    c.query(fql('${col}.all', col=a_collection))
     assert c.get_last_transaction_time() is not None
 
 
 def test_client_txn_ts_are_independent(client, a_collection):
     c = Client()
-    c.query(fql('$col.all', col=a_collection))
+    c.query(fql('${col}.all', col=a_collection))
     assert client.get_last_transaction_time() is not None
     assert c.get_last_transaction_time() is not None
     assert client.get_last_transaction_time() != c.get_last_transaction_time()

--- a/tests/integration/test_data_type_roundtrips.py
+++ b/tests/integration/test_data_type_roundtrips.py
@@ -6,62 +6,62 @@ from fauna import fql
 def test_float_roundtrip(client):
     f = 0.1 + 0.1 + 0.1
     assert f != 0.3
-    test = fql("$float", float=f)
+    test = fql("${float}", float=f)
     result = client.query(test).data
     assert result == f
 
 
 def test_32_bit_int_roundtrip(client):
     i = 2147483648
-    test = fql("$int", int=i)
+    test = fql("${int}", int=i)
     result = client.query(test).data
     assert result == i
 
 
 def test_64_bit_int_roundtrip(client):
     lng = 9223372036854775807
-    test = fql("$long", long=lng)
+    test = fql("${long}", long=lng)
     result = client.query(test).data
     assert result == lng
 
 
 def test_string_roundtrip(client):
     s = "there and back again"
-    test = fql("$str", str=s)
+    test = fql("${str}", str=s)
     result = client.query(test).data
     assert result == s
 
 
 def test_true_roundtrip(client):
     b = True
-    test = fql("$bool", bool=b)
+    test = fql("${bool}", bool=b)
     result = client.query(test).data
     assert result == b
 
 
 def test_false_roundtrip(client):
     b = False
-    test = fql("$bool", bool=b)
+    test = fql("${bool}", bool=b)
     result = client.query(test).data
     assert result == b
 
 
 def test_datetime_utc_roundtrip(client):
     dt = datetime(2023, 2, 10, tzinfo=timezone.utc)
-    test = fql("$datetime", datetime=dt)
+    test = fql("${datetime}", datetime=dt)
     result = client.query(test).data
     assert result == dt
 
 
 def test_datetime_non_utc_roundtrip(client):
     dt = datetime(2023, 2, 10, tzinfo=timezone(timedelta(hours=2, minutes=0)))
-    test = fql("$datetime", datetime=dt)
+    test = fql("${datetime}", datetime=dt)
     result = client.query(test).data
     assert result == dt
 
 
 def test_none_roundtrip(client):
     none = None
-    test = fql("$none", none=none)
+    test = fql("${none}", none=none)
     result = client.query(test).data
     assert result == none

--- a/tests/unit/test_query_builder.py
+++ b/tests/unit/test_query_builder.py
@@ -16,7 +16,7 @@ def test_query_builder_strings(subtests):
 
 
 def test_query_builder_supports_fauna_interpolated_strings():
-    q = fql("""let age = $n1\n\"Alice is #{age} years old.\"""", n1=5)
+    q = fql("""let age = ${n1}\n\"Alice is #{age} years old.\"""", n1=5)
     r = q.to_query()
     assert r == {
         "fql": [
@@ -34,7 +34,7 @@ def test_query_builder_supports_fauna_interpolated_strings():
 def test_query_builder_values(subtests):
     with subtests.test(msg="simple value"):
         user = {"name": "Dino", "age": 0, "birthdate": date(2023, 2, 24)}
-        q = fql("""let x = $my_var""", my_var=user)
+        q = fql("""let x = ${my_var}""", my_var=user)
         r = q.to_query()
         assert r == {
             "fql": [
@@ -56,8 +56,8 @@ def test_query_builder_values(subtests):
 def test_query_builder_sub_queries(subtests):
     with subtests.test(msg="single subquery with object"):
         user = {"name": "Dino", "age": 0, "birthdate": date(2023, 2, 24)}
-        inner = fql("""let x = $my_var""", my_var=user)
-        outer = fql("""$inner
+        inner = fql("""let x = ${my_var}""", my_var=user)
+        outer = fql("""${inner}
 x { .name }""", inner=inner)
 
         r = outer.to_query()

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -6,13 +6,13 @@ from fauna.template import FaunaTemplate
 def test_templates_with_variables(subtests):
 
     with subtests.test(msg="single variable template"):
-        template = FaunaTemplate("""let x = $my_var""")
+        template = FaunaTemplate("""let x = ${my_var}""")
         expanded = [p for p in template.iter()]
         assert expanded == [("let x = ", "my_var")]
 
     with subtests.test(msg="duplicate variable template"):
-        template = FaunaTemplate("""let x = $my_var
-let y = $my_var
+        template = FaunaTemplate("""let x = ${my_var}
+let y = ${my_var}
 x * y""")
         expanded = [p for p in template.iter()]
         assert expanded == [
@@ -22,7 +22,7 @@ x * y""")
         ]
 
     with subtests.test(msg="variable at start of template"):
-        template = FaunaTemplate("""$my_var { .name }""")
+        template = FaunaTemplate("""${my_var} { .name }""")
         expanded = [p for p in template.iter()]
         assert expanded == [
             (None, "my_var"),
@@ -33,18 +33,18 @@ x * y""")
 def test_templates_with_escapes(subtests):
 
     with subtests.test(msg="escaped variable template expansion"):
-        template = FaunaTemplate("""let x = '$$not_a_var'""")
+        template = FaunaTemplate("""let x = '$${not_a_var}'""")
         expanded = [p for p in template.iter()]
         assert expanded == [
             ("let x = '$", None),
-            ("not_a_var'", None),
+            ("{not_a_var}'", None),
         ]
 
 
 def test_templates_with_unsupported_identifiers(subtests):
 
     with subtests.test(msg="variable with unsupported unicode"):
-        template = FaunaTemplate("""let x = $かわいい""")
+        template = FaunaTemplate("""let x = ${かわいい}""")
         err_msg = "Invalid placeholder in template: line 1, col 9"
         with pytest.raises(ValueError, match=err_msg):
             _ = [p for p in template.iter()]


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-###, FE-###,...

## Problem

We discussed templates formats being common across drivers. This brings the python implem in line with JS.

## Solution

Capture braced $ vars instead.

## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

Tests updated. they still pass
