### PR TITLE
Remove txn_ts from request API

### DIFF
--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -3,14 +3,14 @@ from fauna import Client, fql
 
 def test_client_tracks_last_txn_ts(a_collection):
     c = Client()
-    assert c.get_last_transaction_time() is None
+    assert c.get_last_txn_ts() is None
     c.query(fql('${col}.all', col=a_collection))
-    assert c.get_last_transaction_time() is not None
+    assert c.get_last_txn_ts() is not None
 
 
 def test_client_txn_ts_are_independent(client, a_collection):
     c = Client()
     c.query(fql('${col}.all', col=a_collection))
-    assert client.get_last_transaction_time() is not None
-    assert c.get_last_transaction_time() is not None
-    assert client.get_last_transaction_time() != c.get_last_transaction_time()
+    assert client.get_last_txn_ts() is not None
+    assert c.get_last_txn_ts() is not None
+    assert client.get_last_txn_ts() != c.get_last_txn_ts()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -26,11 +26,6 @@ def query_timeout_ms() -> int:
 
 
 @pytest.fixture
-def last_txn_ts() -> int:
-    return randint(1, 1000)
-
-
-@pytest.fixture
 def traceparent() -> str:
     return "happy-little-fox"
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -72,10 +72,10 @@ def test_client_with_args():
 
 def test_get_set_transaction_time():
     c = Client()
-    assert c.get_last_transaction_time() is None
+    assert c.get_last_txn_ts() is None
 
-    c.set_last_transaction_time(123)
-    assert c.get_last_transaction_time() == 123
+    c.set_last_txn_ts(123)
+    assert c.get_last_txn_ts() == 123
 
 
 def test_get_query_timeout():
@@ -93,7 +93,6 @@ def test_query_options_set(
     traceparent: str,
     tags: Mapping[str, str],
     max_contention_retries: int,
-    last_txn_ts: int,
 ):
 
     def validate_headers(request: httpx.Request):
@@ -108,7 +107,6 @@ def test_query_options_set(
         assert request.headers[Header.Traceparent] == traceparent
         assert request.headers[Header.MaxContentionRetries] \
             == f"{max_contention_retries}"
-        assert request.headers[Header.LastTxnTs] == str(last_txn_ts)
         return httpx.Response(
             status_code=200,
             json={"data": "mocked"},
@@ -130,7 +128,6 @@ def test_query_options_set(
                 query_timeout_ms=query_timeout_ms,
                 traceparent=traceparent,
                 max_contention_retries=max_contention_retries,
-                last_txn_ts=last_txn_ts,
             ),
         )
 


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-###, FE-###,...

## Problem

Per stand up, drivers should align on txn_ts semantics and remove the option from the request API.

## Solution

Describe the modifications you've done.

## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

updated existing tests.
