### PR TITLE
Add a DocumentDict model for @doc protocol change

### DIFF
--- a/fauna/models.py
+++ b/fauna/models.py
@@ -1,25 +1,4 @@
-class DocumentReference:
-
-    def __init__(self, collection_name: str, ref_id: str):
-        self.collection = collection_name
-        self.id = ref_id
-
-    def __str__(self):
-        return f"{self.collection}:{self.id}"
-
-    def __eq__(self, other):
-        return isinstance(other, DocumentReference) and str(self) == str(other)
-
-    def __hash__(self):
-        hash((self.collection, self.id))
-
-    @staticmethod
-    def from_string(ref: str):
-        rs = ref.split(":")
-        if len(rs) != 2:
-            raise ValueError(
-                "Expects string of format <CollectionName>:<RefID>")
-        return DocumentReference(rs[0], rs[1])
+from typing import Union
 
 
 class Module:
@@ -35,3 +14,45 @@ class Module:
 
     def __hash__(self):
         hash(self.name)
+
+
+class DocumentReference:
+    collection: Module
+    ref_id: str
+
+    def __init__(self, collection: Union[str, Module], ref_id: str):
+        if isinstance(collection, str):
+            self.collection = Module(collection)
+        else:
+            self.collection = collection
+
+        self.ref_id = ref_id
+
+    def __str__(self):
+        return f"{self.collection}:{self.ref_id}"
+
+    def __eq__(self, other):
+        return isinstance(other, DocumentReference) and str(self) == str(other)
+
+    def __hash__(self):
+        hash((self.collection, self.ref_id))
+
+    @staticmethod
+    def from_string(ref: str):
+        rs = ref.split(":")
+        if len(rs) != 2:
+            raise ValueError(
+                "Expects string of format <CollectionName>:<RefID>")
+        return DocumentReference(rs[0], rs[1])
+
+
+class DocumentDict(dict):
+
+    def ref(self) -> DocumentReference:
+        for k in ["coll", "id"]:
+            if k not in self:
+                raise ValueError(
+                    f"Document does not contain the required '{k}' key to return a reference"
+                )
+
+        return DocumentReference(self["coll"], self["id"])


### PR DESCRIPTION
BT-3634

## Problem

We have a coming wire protocol change that will wrap documents in a `@doc` tag.

## Solution

Propose a model that should require minimal changes to the current contract once incorporated into the encoding/decoding.

## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

Describe the manual and automated tests you completed to verify the change is working as expected.
