### PR TITLE
Decouple encoding from query building

### DIFF
--- a/fauna/__init__.py
+++ b/fauna/__init__.py
@@ -8,7 +8,7 @@ __copyright__ = "2023 Fauna, Inc"
 from .client import Client
 from .headers import Header
 from .http_client import HTTPClient, HTTPResponse, HTTPXClient
-from .query_builder import fql, QueryBuilder
+from .query_builder import fql, QueryInterpolation
 from .models import DocumentReference, Module
 
 global_http_client = None

--- a/fauna/client.py
+++ b/fauna/client.py
@@ -12,6 +12,7 @@ from fauna.headers import _DriverEnvironment, _Header, _Auth, Header
 from fauna.http_client import HTTPClient, HTTPXClient
 from fauna.query_builder import QueryBuilder
 from fauna.utils import _Environment, LastTxnTs
+from fauna.wire_protocol import FaunaEncoder
 
 DefaultHttpConnectTimeout = timedelta(seconds=5)
 DefaultHttpReadTimeout: Optional[timedelta] = None
@@ -191,13 +192,13 @@ class Client:
         """
 
         try:
-            query = fql.to_query()
+            encoded_query: Mapping[str, Any] = FaunaEncoder.encode(fql)
         except Exception as e:
             raise ClientError("Failed to evaluate Query") from e
 
         return self._query(
             "/query/1",
-            fql=query,
+            fql=encoded_query,
             opts=opts,
         )
 

--- a/fauna/client.py
+++ b/fauna/client.py
@@ -10,7 +10,7 @@ from fauna.errors import AuthenticationError, ClientError, ProtocolError, Servic
     QueryCheckError
 from fauna.headers import _DriverEnvironment, _Header, _Auth, Header
 from fauna.http_client import HTTPClient, HTTPXClient
-from fauna.query_builder import QueryBuilder
+from fauna.query_builder import QueryInterpolation
 from fauna.utils import _Environment, LastTxnTs
 from fauna.wire_protocol import FaunaEncoder
 
@@ -177,7 +177,7 @@ class Client:
 
     def query(
         self,
-        fql: QueryBuilder,
+        fql: QueryInterpolation,
         opts: Optional[QueryOptions] = None,
     ) -> QueryResponse:
         """

--- a/fauna/query_builder.py
+++ b/fauna/query_builder.py
@@ -5,15 +5,14 @@ from fauna.template import FaunaTemplate
 
 
 class QueryBuilder(abc.ABC):
-    """An abstract class for query builders that build to the FQL Query Template wire protocol.
+    """An abstract class for query builders.
     """
 
     @abc.abstractmethod
     def fragments(self) -> Sequence['Fragment']:
-        """An abstract method for converting a builder to query template wire protocol.
-        e.g. ``{ "fql": [ ... ] }``
+        """An abstract method accessing fragments.
 
-        :returns: a rendered query template
+        :returns: the stored fragments
         """
         pass
 
@@ -24,13 +23,13 @@ class Fragment(abc.ABC):
 
     @abc.abstractmethod
     def get(self) -> Any:
-        """An abstract method for rendering the :class:`Fragment` into a query part.
+        """An abstract method for returning a stored value.
         """
         pass
 
 
 class ValueFragment(Fragment):
-    """A concrete :class:`Fragment` representing a part of a query that will become a type tagged object on the wire.
+    """A concrete :class:`Fragment` representing a part of a query that can represent a template variable.
     For example, if a template contains a variable ``${foo}``, and an object ``{ "prop": 1 }`` is provided for foo,
     then ``{ "prop": 1 }`` should be wrapped as a :class:`ValueFragment`.
 
@@ -59,17 +58,17 @@ class LiteralFragment(Fragment):
         self._val = val
 
     def get(self) -> str:
-        """Renders the :class:`LiteralFragment` into the wire protocol for a literal of the query template API.
+        """Returns the stored value.
 
-        e.g. ``let x = ``
-
-        :returns: The query literal.
+        :returns: The stored value.
         """
         return self._val
 
 
 class QueryInterpolationBuilder(QueryBuilder):
-    """A concrete :class:`QueryBuilder` for building queries into the query template wire protocol.
+    """A concrete :class:`QueryBuilder` for building QueryInteroplation queries.
+
+       e.g. { "fql": [...] }
     """
     _rendered: Optional[Mapping[str, Any]]
     _fragments: List[Fragment]
@@ -86,7 +85,7 @@ class QueryInterpolationBuilder(QueryBuilder):
 
 def fql(query: str, **kwargs: Any) -> QueryBuilder:
     """Creates a QueryBuilder - capable of performing query composition and simple querying. It can accept a simple
-    string query, or can perform composition using ${}-sigil string template with ``**kwargs`` as substitutions.
+    string query, or can perform composition using ``${}`` sigil string template with ``**kwargs`` as substitutions.
 
     The ``**kwargs`` can be Fauna data types - such as strings, document references, or modules - and embedded
     QueryBuilders - allowing you to compose arbitrarily complex queries.

--- a/fauna/query_builder.py
+++ b/fauna/query_builder.py
@@ -1,20 +1,7 @@
 import abc
-from typing import Any, Sequence, Mapping, Optional, List
+from typing import Any, Optional, List
 
 from fauna.template import FaunaTemplate
-
-
-class QueryBuilder(abc.ABC):
-    """An abstract class for query builders.
-    """
-
-    @abc.abstractmethod
-    def fragments(self) -> Sequence['Fragment']:
-        """An abstract method accessing fragments.
-
-        :returns: the stored fragments
-        """
-        pass
 
 
 class Fragment(abc.ABC):
@@ -65,16 +52,14 @@ class LiteralFragment(Fragment):
         return self._val
 
 
-class QueryInterpolationBuilder(QueryBuilder):
-    """A concrete :class:`QueryBuilder` for building QueryInteroplation queries.
+class QueryInterpolation:
+    """A class for building Query Interpolation queries.
 
        e.g. { "fql": [...] }
     """
-    _rendered: Optional[Mapping[str, Any]]
     _fragments: List[Fragment]
 
     def __init__(self, fragments: Optional[List[Fragment]] = None):
-        self._rendered = None
         self._fragments = fragments or []
 
     @property
@@ -83,19 +68,20 @@ class QueryInterpolationBuilder(QueryBuilder):
         return self._fragments
 
 
-def fql(query: str, **kwargs: Any) -> QueryBuilder:
-    """Creates a QueryBuilder - capable of performing query composition and simple querying. It can accept a simple
-    string query, or can perform composition using ``${}`` sigil string template with ``**kwargs`` as substitutions.
+def fql(query: str, **kwargs: Any) -> QueryInterpolation:
+    """Creates a QueryInterpolation - capable of performing query composition and simple querying. It can accept a
+    simple string query, or can perform composition using ``${}`` sigil string template with ``**kwargs`` as
+    substitutions.
 
     The ``**kwargs`` can be Fauna data types - such as strings, document references, or modules - and embedded
-    QueryBuilders - allowing you to compose arbitrarily complex queries.
+    QueryInterpolation - allowing you to compose arbitrarily complex queries.
 
     When providing ``**kwargs``, following types are accepted:
         - :class:`str`, :class:`int`, :class:`float`, :class:`bool`, :class:`datetime.datetime`, :class:`datetime.date`,
-          :class:`dict`, :class:`list`, :class:`QueryBuilder`, :class:`DocumentReference`, :class:`Module`
+          :class:`dict`, :class:`list`, :class:`QueryInterpolation`, :class:`DocumentReference`, :class:`Module`
 
     :raises ValueError: If there is an invalid template placeholder or a value that cannot be encoded.
-    :returns: A :class:`QueryBuilder` that can be passed to the client for evaluation against Fauna.
+    :returns: A :class:`QueryInterpolation` that can be passed to the client for evaluation against Fauna.
 
     Examples:
 
@@ -133,4 +119,4 @@ def fql(query: str, **kwargs: Any) -> QueryBuilder:
 
             # TODO: Reject if it's already a fragment, or accept *Fragment? Decide on API here
             fragments.append(ValueFragment(kwargs[field_name]))
-    return QueryInterpolationBuilder(fragments)
+    return QueryInterpolation(fragments)

--- a/fauna/wire_protocol.py
+++ b/fauna/wire_protocol.py
@@ -23,35 +23,42 @@ _RESERVED_TAGS = [
 class FaunaEncoder:
     """Supports the following types:
 
-    +-------------------+---------------+
-    | Python            | Fauna Tags    |
-    +===================+===============+
-    | dict              | @object       |
-    +-------------------+---------------+
-    | list, tuple       | array         |
-    +-------------------+---------------+
-    | str               | string        |
-    +-------------------+---------------+
-    | int 32-bit signed | @int          |
-    +-------------------+---------------+
-    | int 64-bit signed | @long         |
-    +-------------------+---------------+
-    | float             | @double       |
-    +-------------------+---------------+
-    | datetime.datetime | @time         |
-    +-------------------+---------------+
-    | datetime.date     | @date         |
-    +-------------------+---------------+
-    | True              | True          |
-    +-------------------+---------------+
-    | False             | False         |
-    +-------------------+---------------+
-    | None              | None          |
-    +-------------------+---------------+
-    | DocumentReference | @doc          |
-    +-------------------+---------------+
-    | Module            | @mod          |
-    +-------------------+---------------+
+    +-------------------------------+---------------+
+    | Python                        | Fauna Tags    |
+    +===============================+===============+
+    | dict                          | @object       |
+    +-------------------------------+---------------+
+    | list, tuple                   | array         |
+    +-------------------------------+---------------+
+    | str                           | string        |
+    +-------------------------------+---------------+
+    | int 32-bit signed             | @int          |
+    +-------------------------------+---------------+
+    | int 64-bit signed             | @long         |
+    +-------------------------------+---------------+
+    | float                         | @double       |
+    +-------------------------------+---------------+
+    | datetime.datetime             | @time         |
+    +-------------------------------+---------------+
+    | datetime.date                 | @date         |
+    +-------------------------------+---------------+
+    | True                          | True          |
+    +-------------------------------+---------------+
+    | False                         | False         |
+    +-------------------------------+---------------+
+    | None                          | None          |
+    +-------------------------------+---------------+
+    | DocumentReference             | @doc          |
+    +-------------------------------+---------------+
+    | Module                        | @mod          |
+    +-------------------------------+---------------+
+    | QueryInterpolationBuilder     | fql           |
+    +-------------------------------+---------------+
+    | ValueFragment                 | value         |
+    +-------------------------------+---------------+
+    | TemplateFragment              | string        |
+    +-------------------------------+---------------+
+
     """
 
     @staticmethod
@@ -66,6 +73,9 @@ class FaunaEncoder:
             - date encodes to { "@date": "..." }
             - DocumentReference encodes to { "@doc": "..." }
             - Module encodes to { "@mod": "..." }
+            - QueryInterpolationBuilder encodes to { "fql": [...] }
+            - ValueFragment encodes to { "value": <encoded_val> }
+            - LiteralFragment encodes to a string
 
         :raises ValueError: If value cannot be encoded, cannot be encoded safely, or there's a circular reference.
         :param obj: the object to decode

--- a/fauna/wire_protocol.py
+++ b/fauna/wire_protocol.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Set
 from iso8601 import parse_date
 
 from fauna.models import DocumentReference, Module
-from fauna.query_builder import QueryInterpolationBuilder, Fragment, LiteralFragment, ValueFragment
+from fauna.query_builder import QueryInterpolation, Fragment, LiteralFragment, ValueFragment
 
 _RESERVED_TAGS = [
     "@date",
@@ -137,7 +137,7 @@ class FaunaEncoder:
             return obj.get()
         elif isinstance(obj, ValueFragment):
             v = obj.get()
-            if isinstance(v, QueryInterpolationBuilder):
+            if isinstance(v, QueryInterpolation):
                 return FaunaEncoder.from_query_interpolation_builder(v)
             else:
                 return {"value": FaunaEncoder.encode(v)}
@@ -145,7 +145,7 @@ class FaunaEncoder:
             raise ValueError(f"Unknown fragment type: {type(obj)}")
 
     @staticmethod
-    def from_query_interpolation_builder(obj: QueryInterpolationBuilder):
+    def from_query_interpolation_builder(obj: QueryInterpolation):
         return {"fql": [FaunaEncoder.from_fragment(f) for f in obj.fragments]}
 
     @staticmethod
@@ -177,7 +177,7 @@ class FaunaEncoder:
             return FaunaEncoder._encode_list(o, _markers)
         elif isinstance(o, dict):
             return FaunaEncoder._encode_dict(o, _markers)
-        elif isinstance(o, QueryInterpolationBuilder):
+        elif isinstance(o, QueryInterpolation):
             return FaunaEncoder.from_query_interpolation_builder(o)
         else:
             raise ValueError(f"Object {o} of type {type(o)} cannot be encoded")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,11 +4,11 @@ import string
 import pytest
 
 import fauna
-from fauna import fql, Client, QueryBuilder
+from fauna import fql, Client, QueryInterpolation
 from fauna.models import Module
 
 
-def create_collection(name) -> QueryBuilder:
+def create_collection(name) -> QueryInterpolation:
     return fql('Collection.create({ name: ${name} })', name=name)
 
 

--- a/tests/unit/test_query_builder.py
+++ b/tests/unit/test_query_builder.py
@@ -1,19 +1,19 @@
 from datetime import date
 from typing import Any
 
-from fauna.query_builder import fql, QueryInterpolationBuilder, LiteralFragment, ValueFragment
+from fauna.query_builder import fql, QueryInterpolation, LiteralFragment, ValueFragment
 
 
 def assert_builders(expected: Any, actual: Any):
-    if not (isinstance(expected, QueryInterpolationBuilder)
-            and isinstance(actual, QueryInterpolationBuilder)):
+    if not (isinstance(expected, QueryInterpolation)
+            and isinstance(actual, QueryInterpolation)):
         return False
 
     efs = expected.fragments
     afs = actual.fragments
 
     for i, f in enumerate(efs):
-        if isinstance(f.get(), QueryInterpolationBuilder):
+        if isinstance(f.get(), QueryInterpolation):
             assert_builders(f.get(), afs[i].get())
         assert f.get() == afs[i].get()
 
@@ -23,19 +23,18 @@ def assert_builders(expected: Any, actual: Any):
 def test_query_builder_strings(subtests):
     with subtests.test(msg="pure string query"):
         actual = fql("let x = 11")
-        expected = QueryInterpolationBuilder([LiteralFragment("let x = 11")])
+        expected = QueryInterpolation([LiteralFragment("let x = 11")])
         assert_builders(expected, actual)
 
     with subtests.test(msg="pure string query with braces"):
         actual = fql("let x = { y: 11 }")
-        expected = QueryInterpolationBuilder(
-            [LiteralFragment("let x = { y: 11 }")])
+        expected = QueryInterpolation([LiteralFragment("let x = { y: 11 }")])
         assert_builders(expected, actual)
 
 
 def test_query_builder_supports_fauna_interpolated_strings():
     actual = fql("""let age = ${n1}\n\"Alice is #{age} years old.\"""", n1=5)
-    expected = QueryInterpolationBuilder([
+    expected = QueryInterpolation([
         LiteralFragment("let age = "),
         ValueFragment(5),
         LiteralFragment("\n\"Alice is #{age} years old.\""),
@@ -48,7 +47,7 @@ def test_query_builder_values(subtests):
     with subtests.test(msg="simple value"):
         user = {"name": "Dino", "age": 0, "birthdate": date(2023, 2, 24)}
         actual = fql("""let x = ${my_var}""", my_var=user)
-        expected = QueryInterpolationBuilder([
+        expected = QueryInterpolation([
             LiteralFragment("let x = "),
             ValueFragment(user),
         ])
@@ -61,7 +60,7 @@ def test_query_builder_sub_queries(subtests):
         user = {"name": "Dino", "age": 0, "birthdate": date(2023, 2, 24)}
         inner = fql("""let x = ${my_var}""", my_var=user)
         actual = fql("${inner}\nx { .name }", inner=inner)
-        expected = QueryInterpolationBuilder([
+        expected = QueryInterpolation([
             ValueFragment(inner),
             LiteralFragment("\nx { .name }"),
         ])

--- a/tests/unit/test_query_builder.py
+++ b/tests/unit/test_query_builder.py
@@ -1,81 +1,69 @@
 from datetime import date
+from typing import Any
 
-from fauna.query_builder import fql
+from fauna.query_builder import fql, QueryInterpolationBuilder, LiteralFragment, ValueFragment
+
+
+def assert_builders(expected: Any, actual: Any):
+    if not (isinstance(expected, QueryInterpolationBuilder)
+            and isinstance(actual, QueryInterpolationBuilder)):
+        return False
+
+    efs = expected.fragments
+    afs = actual.fragments
+
+    for i, f in enumerate(efs):
+        if isinstance(f.get(), QueryInterpolationBuilder):
+            assert_builders(f.get(), afs[i].get())
+        assert f.get() == afs[i].get()
+
+    assert len(efs) == len(afs)
 
 
 def test_query_builder_strings(subtests):
     with subtests.test(msg="pure string query"):
-        q = fql("""let x = 11""")
-        r = q.to_query()
-        assert r == {"fql": ["let x = 11"]}
+        actual = fql("let x = 11")
+        expected = QueryInterpolationBuilder([LiteralFragment("let x = 11")])
+        assert_builders(expected, actual)
 
     with subtests.test(msg="pure string query with braces"):
-        q = fql("""let x = { y: 11 }""")
-        r = q.to_query()
-        assert r == {"fql": ["let x = { y: 11 }"]}
+        actual = fql("let x = { y: 11 }")
+        expected = QueryInterpolationBuilder(
+            [LiteralFragment("let x = { y: 11 }")])
+        assert_builders(expected, actual)
 
 
 def test_query_builder_supports_fauna_interpolated_strings():
-    q = fql("""let age = ${n1}\n\"Alice is #{age} years old.\"""", n1=5)
-    r = q.to_query()
-    assert r == {
-        "fql": [
-            "let age = ",
-            {
-                "value": {
-                    "@int": "5"
-                }
-            },
-            "\n\"Alice is #{age} years old.\"",
-        ]
-    }
+    actual = fql("""let age = ${n1}\n\"Alice is #{age} years old.\"""", n1=5)
+    expected = QueryInterpolationBuilder([
+        LiteralFragment("let age = "),
+        ValueFragment(5),
+        LiteralFragment("\n\"Alice is #{age} years old.\""),
+    ])
+
+    assert_builders(expected, actual)
 
 
 def test_query_builder_values(subtests):
     with subtests.test(msg="simple value"):
         user = {"name": "Dino", "age": 0, "birthdate": date(2023, 2, 24)}
-        q = fql("""let x = ${my_var}""", my_var=user)
-        r = q.to_query()
-        assert r == {
-            "fql": [
-                "let x = ", {
-                    'value': {
-                        'name': 'Dino',
-                        'age': {
-                            '@int': '0'
-                        },
-                        'birthdate': {
-                            '@date': '2023-02-24'
-                        }
-                    }
-                }
-            ]
-        }
+        actual = fql("""let x = ${my_var}""", my_var=user)
+        expected = QueryInterpolationBuilder([
+            LiteralFragment("let x = "),
+            ValueFragment(user),
+        ])
+
+        assert_builders(expected, actual)
 
 
 def test_query_builder_sub_queries(subtests):
     with subtests.test(msg="single subquery with object"):
         user = {"name": "Dino", "age": 0, "birthdate": date(2023, 2, 24)}
         inner = fql("""let x = ${my_var}""", my_var=user)
-        outer = fql("""${inner}
-x { .name }""", inner=inner)
+        actual = fql("${inner}\nx { .name }", inner=inner)
+        expected = QueryInterpolationBuilder([
+            ValueFragment(inner),
+            LiteralFragment("\nx { .name }"),
+        ])
 
-        r = outer.to_query()
-
-        assert r == {
-            "fql": [{
-                "fql": [
-                    "let x = ", {
-                        'value': {
-                            'name': 'Dino',
-                            'age': {
-                                '@int': '0'
-                            },
-                            'birthdate': {
-                                '@date': '2023-02-24'
-                            }
-                        }
-                    }
-                ]
-            }, "\nx { .name }"]
-        }
+        assert_builders(expected, actual)


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem

In the throws of rapid development, query building and encoding were coupled.

## Solution

Decouple them by embedding the encoding protocol for a query builder in the encoding module rather than letting the builder encode itself and take a dependency on the encoder.

## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

* Updated unit tests