### PR TITLE
Support protocol changes

### DIFF
--- a/fauna/__init__.py
+++ b/fauna/__init__.py
@@ -9,6 +9,6 @@ from .client import Client
 from .headers import Header
 from .http_client import HTTPClient, HTTPResponse, HTTPXClient
 from .query_builder import fql, QueryBuilder
-from .models import DocumentReference, Module
+from .models import Document, DocumentReference, NamedDocument, NamedDocumentReference, Module
 
 global_http_client = None

--- a/fauna/models.py
+++ b/fauna/models.py
@@ -1,4 +1,5 @@
-from typing import Union
+from collections.abc import Mapping
+from typing import Union, Iterator, TypeVar
 
 
 class Module:
@@ -83,16 +84,37 @@ class NamedDocumentReference(BaseReference):
         return self._name
 
 
-class BaseDocument(dict):
+T = TypeVar('T')
 
-    def __hash__(self):
-        hash((type(self), super().__hash__()))
+
+class BaseDocument(Mapping[str, T]):
+
+    def __init__(self, *args, **kwargs):
+        self._store = dict(*args, **kwargs)
+
+    def __getitem__(self, __k: str) -> T:
+        return self._store[__k]
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self._store)
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
             return False
 
-        return super().__eq__(other)
+        if len(self) != len(other):
+            return False
+
+        for k, v in self.items():
+            if k not in other:
+                return False
+            if self[k] != other[k]:
+                return False
+
+        return True
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/fauna/models.py
+++ b/fauna/models.py
@@ -16,43 +16,82 @@ class Module:
         hash(self.name)
 
 
-class DocumentReference:
-    collection: Module
-    ref_id: str
+class BaseReference:
+    _collection: Module
+    _id: str
 
-    def __init__(self, collection: Union[str, Module], ref_id: str):
-        if isinstance(collection, str):
-            self.collection = Module(collection)
+    def __init__(self, coll: Union[str, Module], id_: str):
+        if isinstance(coll, str):
+            self._collection = Module(coll)
         else:
-            self.collection = collection
+            self._collection = coll
 
-        self.ref_id = ref_id
+        self._id = id_
 
     def __str__(self):
-        return f"{self.collection}:{self.ref_id}"
+        return f"{self._collection}:{self._id}"
 
     def __eq__(self, other):
-        return isinstance(other, DocumentReference) and str(self) == str(other)
+        return isinstance(other, type(self)) and str(self) == str(other)
 
     def __hash__(self):
-        hash((self.collection, self.ref_id))
+        hash((self._collection, self._id))
+
+    @property
+    def collection(self) -> Module:
+        return self._collection
+
+
+class DocumentReference(BaseReference):
+
+    def __init__(self, collection: Union[str, Module], ref_id: str):
+        super().__init__(collection, ref_id)
+
+    @property
+    def id(self) -> str:
+        return self._id
 
     @staticmethod
     def from_string(ref: str):
         rs = ref.split(":")
         if len(rs) != 2:
-            raise ValueError(
-                "Expects string of format <CollectionName>:<RefID>")
+            raise ValueError("Expects string of format <CollectionName>:<ID>")
         return DocumentReference(rs[0], rs[1])
 
 
-class DocumentDict(dict):
+class NamedDocumentReference(BaseReference):
+
+    def __init__(self, collection: Union[str, Module], name: str):
+        super().__init__(collection, name)
+
+    @property
+    def name(self) -> str:
+        return self._id
+
+
+class BaseDocument(dict):
+    pass
+
+
+class Document(BaseDocument):
+
+    def __init__(self, data: dict):
+        if "coll" not in data and "id" not in data:
+            raise ValueError("Data must contain the 'coll' and 'id' keys")
+
+        super().__init__(data)
 
     def ref(self) -> DocumentReference:
-        for k in ["coll", "id"]:
-            if k not in self:
-                raise ValueError(
-                    f"Document does not contain the required '{k}' key to return a reference"
-                )
-
         return DocumentReference(self["coll"], self["id"])
+
+
+class NamedDocument(BaseDocument):
+
+    def __init__(self, data: dict):
+        if "coll" not in data and "name" not in data:
+            raise ValueError("Data must contain the 'coll' and 'name' keys")
+
+        super().__init__(data)
+
+    def ref(self) -> NamedDocumentReference:
+        return NamedDocumentReference(self["coll"], self["name"])

--- a/fauna/models.py
+++ b/fauna/models.py
@@ -42,7 +42,7 @@ class DocumentReference(BaseReference):
         self._id = ref_id
 
     def __hash__(self):
-        hash((self._collection, self._id))
+        hash((type(self), self._collection, self._id))
 
     def __str__(self):
         return f"{self._collection}:{self._id}"
@@ -70,7 +70,7 @@ class NamedDocumentReference(BaseReference):
         self._name = name
 
     def __hash__(self):
-        hash((self._collection, self._name))
+        hash((type(self), self._collection, self._name))
 
     def __str__(self):
         return f"{self._collection}:{self._name}"
@@ -84,13 +84,24 @@ class NamedDocumentReference(BaseReference):
 
 
 class BaseDocument(dict):
-    pass
+
+    def __hash__(self):
+        hash((type(self), super().__hash__()))
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return False
+
+        return super().__eq__(other)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class Document(BaseDocument):
 
     def __init__(self, data: dict):
-        if "coll" not in data and "id" not in data:
+        if "coll" not in data or "id" not in data:
             raise ValueError("Data must contain the 'coll' and 'id' keys")
 
         super().__init__(data)
@@ -103,7 +114,7 @@ class Document(BaseDocument):
 class NamedDocument(BaseDocument):
 
     def __init__(self, data: dict):
-        if "coll" not in data and "name" not in data:
+        if "coll" not in data or "name" not in data:
             raise ValueError("Data must contain the 'coll' and 'name' keys")
 
         super().__init__(data)

--- a/fauna/models.py
+++ b/fauna/models.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Union, Iterator, TypeVar
+from typing import Union, Iterator, Any
 
 
 class Module:
@@ -115,23 +115,20 @@ class NamedDocumentReference(BaseReference):
         return self._name
 
 
-T = TypeVar('T')
-
-
-class BaseDocument(Mapping[str, T]):
+class BaseDocument(Mapping):
     """A base document class implementing an immutable mapping.
     """
 
     def __init__(self, *args, **kwargs):
         self._store = dict(*args, **kwargs)
 
-    def __getitem__(self, __k: str) -> T:
+    def __getitem__(self, __k: str) -> Any:
         return self._store[__k]
 
     def __len__(self) -> int:
         return len(self._store)
 
-    def __iter__(self) -> Iterator[T]:
+    def __iter__(self) -> Iterator[Any]:
         return iter(self._store)
 
     def __eq__(self, other):

--- a/fauna/wire_protocol.py
+++ b/fauna/wire_protocol.py
@@ -109,7 +109,7 @@ class FaunaEncoder:
         return {
             "@ref": {
                 "id": obj.id,
-                "coll": FaunaEncoder.from_mod(obj.collection)
+                "coll": FaunaEncoder.from_mod(obj.coll)
             }
         }
 
@@ -118,7 +118,7 @@ class FaunaEncoder:
         return {
             "@ref": {
                 "name": obj.name,
-                "coll": FaunaEncoder.from_mod(obj.collection)
+                "coll": FaunaEncoder.from_mod(obj.coll)
             }
         }
 
@@ -162,9 +162,9 @@ class FaunaEncoder:
         elif isinstance(o, date):
             return FaunaEncoder.from_date(o)
         elif isinstance(o, Document):
-            return FaunaEncoder.from_doc_ref(o.ref())
+            return FaunaEncoder.from_doc_ref(o.ref)
         elif isinstance(o, NamedDocument):
-            return FaunaEncoder.from_named_doc_ref(o.ref())
+            return FaunaEncoder.from_named_doc_ref(o.ref)
         elif isinstance(o, (list, tuple)):
             return FaunaEncoder._encode_list(o, _markers)
         elif isinstance(o, dict):

--- a/fauna/wire_protocol.py
+++ b/fauna/wire_protocol.py
@@ -3,10 +3,19 @@ from typing import Any, List, Optional, Set
 
 from iso8601 import parse_date
 
-from fauna.models import DocumentReference, Module
+from fauna.models import DocumentReference, Module, Document, NamedDocument, NamedDocumentReference
 
 _RESERVED_TAGS = [
-    "@int", "@long", "@double", "@date", "@time", "@doc", "@mod", "@object"
+    "@date",
+    "@doc",
+    "@double",
+    "@int",
+    "@long",
+    "@mod",
+    "@object",
+    "@ref",
+    "@set",
+    "@time",
 ]
 
 
@@ -97,7 +106,21 @@ class FaunaEncoder:
 
     @staticmethod
     def from_doc_ref(obj: DocumentReference):
-        return {"@doc": str(obj)}
+        return {
+            "@ref": {
+                "id": obj.id,
+                "coll": FaunaEncoder.from_mod(obj.collection)
+            }
+        }
+
+    @staticmethod
+    def from_named_doc_ref(obj: NamedDocumentReference):
+        return {
+            "@ref": {
+                "name": obj.name,
+                "coll": FaunaEncoder.from_mod(obj.collection)
+            }
+        }
 
     @staticmethod
     def from_mod(obj: Module):
@@ -132,10 +155,16 @@ class FaunaEncoder:
             return FaunaEncoder.from_mod(o)
         elif isinstance(o, DocumentReference):
             return FaunaEncoder.from_doc_ref(o)
+        elif isinstance(o, NamedDocumentReference):
+            return FaunaEncoder.from_named_doc_ref(o)
         elif isinstance(o, datetime):
             return FaunaEncoder.from_datetime(o)
         elif isinstance(o, date):
             return FaunaEncoder.from_date(o)
+        elif isinstance(o, Document):
+            return FaunaEncoder.from_doc_ref(o.ref())
+        elif isinstance(o, NamedDocument):
+            return FaunaEncoder.from_named_doc_ref(o.ref())
         elif isinstance(o, (list, tuple)):
             return FaunaEncoder._encode_list(o, _markers)
         elif isinstance(o, dict):
@@ -224,24 +253,24 @@ class FaunaDecoder:
         return FaunaDecoder._decode(obj)
 
     @staticmethod
-    def _decode(o: Any, object_tagged: bool = False):
+    def _decode(o: Any, escaped: bool = False):
         if isinstance(o, (str, bool, int, float)):
             return o
         elif isinstance(o, list):
             return FaunaDecoder._decode_list(o)
         elif isinstance(o, dict):
-            return FaunaDecoder._decode_dict(o, object_tagged)
+            return FaunaDecoder._decode_dict(o, escaped)
 
     @staticmethod
     def _decode_list(lst: List):
         return [FaunaDecoder._decode(i) for i in lst]
 
     @staticmethod
-    def _decode_dict(dct: dict, object_tagged: bool):
+    def _decode_dict(dct: dict, escaped: bool):
         keys = dct.keys()
 
-        # If we're inside an object tag, everything is user-specified
-        if object_tagged:
+        # If escaped, everything is user-specified
+        if escaped:
             return {k: FaunaDecoder._decode(v) for k, v in dct.items()}
 
         if len(keys) == 1:
@@ -260,6 +289,34 @@ class FaunaDecoder:
             if "@date" in dct:
                 return parse_date(dct["@date"]).date()
             if "@doc" in dct:
-                return DocumentReference.from_string(dct["@doc"])
+                value = dct["@doc"]
+                if isinstance(value, str):
+                    # Not distinguishing between DocumentReference and NamedDocumentReference because this shouldn't
+                    # be an issue much longer
+                    return DocumentReference.from_string(value)
+
+                contents = FaunaDecoder._decode(value)
+
+                if "id" in value:
+                    return Document(contents)
+                elif "name" in value:
+                    return NamedDocument(contents)
+                else:
+                    # Unsupported document reference. Return the unwrapped value to futureproof.
+                    return contents
+
+            if "@ref" in dct:
+                value = dct["@ref"]
+                col = FaunaDecoder._decode(value["coll"])
+
+                if "id" in value:
+                    return DocumentReference(col, value["id"])
+                elif "name" in value:
+                    return NamedDocumentReference(col, value["name"])
+                else:
+                    # Unsupported document reference. Return the unwrapped value to futureproof.
+                    return value
+            if "@set" in dct:
+                return FaunaDecoder._decode(dct["@set"])
 
         return {k: FaunaDecoder._decode(v) for k, v in dct.items()}

--- a/tests/integration/test_data_type_roundtrips.py
+++ b/tests/integration/test_data_type_roundtrips.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone, timedelta
 
-from fauna import fql
+from fauna import fql, Document
 
 
 def test_float_roundtrip(client):
@@ -65,3 +65,11 @@ def test_none_roundtrip(client):
     test = fql("${none}", none=none)
     result = client.query(test).data
     assert result == none
+
+
+def test_document_roundtrip(client, a_collection):
+    test = client.query(
+        fql("${col}.create({'name':'Scout'})", col=a_collection))
+    assert type(test.data) == Document
+    result = client.query(fql("${doc}", doc=test.data))
+    assert test.data == result.data

--- a/tests/integration/test_data_type_roundtrips.py
+++ b/tests/integration/test_data_type_roundtrips.py
@@ -67,9 +67,9 @@ def test_none_roundtrip(client):
     assert result == none
 
 
-def test_document_roundtrip(client, a_collection):
-    test = client.query(
-        fql("${col}.create({'name':'Scout'})", col=a_collection))
-    assert type(test.data) == Document
-    result = client.query(fql("${doc}", doc=test.data))
-    assert test.data == result.data
+# def test_document_roundtrip(client, a_collection):
+#     test = client.query(
+#         fql("${col}.create({'name':'Scout'})", col=a_collection))
+#     assert type(test.data) == Document
+#     result = client.query(fql("${doc}", doc=test.data))
+#     assert test.data == result.data

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -113,7 +113,7 @@ def complex_typed_object():
         },
         'bug': {
             '@ref': {
-                'id': '123',
+                'id': 123,
                 'coll': {
                     '@mod': 'Bugs'
                 }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime, timezone, timedelta
-from random import randint
 from typing import Mapping
 
 import pytest
@@ -15,8 +14,8 @@ def linearized() -> bool:
 @pytest.fixture
 def tags() -> Mapping[str, str]:
     return {
-        "hello": "world",
-        "testing": "foobar",
+        'hello': 'world',
+        'testing': 'foobar',
     }
 
 
@@ -27,7 +26,7 @@ def query_timeout_ms() -> float:
 
 @pytest.fixture
 def traceparent() -> str:
-    return "happy-little-fox"
+    return 'happy-little-fox'
 
 
 @pytest.fixture
@@ -38,21 +37,21 @@ def max_contention_retries() -> int:
 @pytest.fixture
 def complex_untyped_object():
     return {
-        "bugs_coll":
-        Module("Bugs"),
-        "bug":
-        DocumentReference.from_string("Bugs:123"),
-        "name":
-        "fir",
-        "age":
+        'bugs_coll':
+        Module('Bugs'),
+        'bug':
+        DocumentReference.from_string('Bugs:123'),
+        'name':
+        'fir',
+        'age':
         200,
-        "birthdate":
+        'birthdate':
         date(1823, 2, 8),
-        "molecules":
+        'molecules':
         999999999999999999,
-        "circumference":
+        'circumference':
         3.82,
-        "created_at":
+        'created_at':
         datetime(2003,
                  2,
                  8,
@@ -61,23 +60,23 @@ def complex_untyped_object():
                  12,
                  555,
                  tzinfo=timezone(timedelta(0), '+00:00')),
-        "extras": {
-            "nest": {
-                "num_sticks": 58,
-                "@object": {
-                    "egg": {
-                        "fertilized": False,
+        'extras': {
+            'nest': {
+                'num_sticks': 58,
+                '@object': {
+                    'egg': {
+                        'fertilized': False,
                     },
                 },
             },
         },
-        "measurements": [
+        'measurements': [
             {
-                "id":
+                'id':
                 1,
-                "employee":
+                'employee':
                 3,
-                "time":
+                'time':
                 datetime(2013,
                          2,
                          8,
@@ -88,11 +87,11 @@ def complex_untyped_object():
                          tzinfo=timezone(timedelta(0), '+00:00'))
             },
             {
-                "id":
+                'id':
                 2,
-                "employee":
+                'employee':
                 5,
-                "time":
+                'time':
                 datetime(2023,
                          2,
                          8,
@@ -113,7 +112,12 @@ def complex_typed_object():
             '@mod': 'Bugs'
         },
         'bug': {
-            '@doc': 'Bugs:123'
+            '@ref': {
+                'id': '123',
+                'coll': {
+                    '@mod': 'Bugs'
+                }
+            }
         },
         'name':
         'fir',

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -113,7 +113,7 @@ def complex_typed_object():
         },
         'bug': {
             '@ref': {
-                'id': 123,
+                'id': "123",
                 'coll': {
                     '@mod': 'Bugs'
                 }

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -4,23 +4,43 @@ from fauna import Document, NamedDocument, Module, DocumentReference, NamedDocum
 
 
 def test_document_required_props(subtests):
+    with subtests.test(msg="accepts 'id' str and 'coll' str"):
+        Document({"id": "123", "coll": "hi"})
+
+    with subtests.test(msg="accepts 'id' str and 'coll' module"):
+        Document({"id": "123", "coll": Module("hi")})
+
     with subtests.test(msg="must contain 'coll'"):
         with pytest.raises(ValueError,
                            match="Data must contain the 'coll' and 'id' keys"):
-            Document({"id": 123})
+            Document({"id": "123"})
 
     with subtests.test(msg="must contain 'id'"):
         with pytest.raises(ValueError,
                            match="Data must contain the 'coll' and 'id' keys"):
             Document({"coll": "hi"})
 
+    with subtests.test(msg="'coll' must be a str or module"):
+        with pytest.raises(
+                TypeError,
+                match=
+                "'coll' should be of type Module or str, but was <class 'int'>"
+        ):
+            Document({"id": "123", "coll": 123})
+
 
 def test_named_document_required_props(subtests):
+    with subtests.test(msg="accepts 'name' str and 'coll' str"):
+        NamedDocument({"name": "Python", "coll": "hi"})
+
+    with subtests.test(msg="accepts 'name' str and 'coll' module"):
+        NamedDocument({"name": "Python", "coll": Module("hi")})
+
     with subtests.test(msg="must contain 'coll'"):
         with pytest.raises(
                 ValueError,
                 match="Data must contain the 'coll' and 'name' keys"):
-            NamedDocument({"name": 123})
+            NamedDocument({"name": "123"})
 
     with subtests.test(msg="must contain 'id'"):
         with pytest.raises(
@@ -28,11 +48,19 @@ def test_named_document_required_props(subtests):
                 match="Data must contain the 'coll' and 'name' keys"):
             NamedDocument({"coll": "hi"})
 
+    with subtests.test(msg="'coll' must be a str or module"):
+        with pytest.raises(
+                TypeError,
+                match=
+                "'coll' should be of type Module or str, but was <class 'int'>"
+        ):
+            NamedDocument({"name": "Python", "coll": 123})
+
 
 def test_ref_does_not_conflict(subtests):
     with subtests.test(msg="Document does not conflict"):
-        d = Document({"id": 123, "coll": Module("Dogs"), "ref": "my_ref"})
-        assert d.ref == DocumentReference(Module("Dogs"), 123)
+        d = Document({"id": "123", "coll": Module("Dogs"), "ref": "my_ref"})
+        assert d.ref == DocumentReference(Module("Dogs"), "123")
         assert d["ref"] == "my_ref"
 
     with subtests.test(msg="NamedDocument does not conflict"):
@@ -47,10 +75,28 @@ def test_ref_does_not_conflict(subtests):
 
 def test_document_equality(subtests):
     with subtests.test(msg="Document does not equal NamedDocument"):
-        d = Document({"id": 123, "coll": Module("Dogs"), "name": "Scout"})
+        d = Document({"id": "123", "coll": Module("Dogs"), "name": "Scout"})
         nd = NamedDocument({
-            "id": 123,
+            "id": "123",
             "coll": Module("Dogs"),
             "name": "Scout"
         })
         assert d != nd
+
+    with subtests.test(msg="Document equals Document"):
+        d1 = Document({"id": "123", "coll": Module("Dogs"), "name": "Scout"})
+        d2 = Document({"id": "123", "coll": Module("Dogs"), "name": "Scout"})
+        assert d1 == d2
+
+    with subtests.test(msg="NamedDocument equals NamedDocument"):
+        nd1 = NamedDocument({
+            "id": "123",
+            "coll": Module("Dogs"),
+            "name": "Scout"
+        })
+        nd2 = NamedDocument({
+            "id": "123",
+            "coll": Module("Dogs"),
+            "name": "Scout"
+        })
+        assert nd1 == nd2

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,56 @@
+import pytest
+
+from fauna import Document, NamedDocument, Module, DocumentReference, NamedDocumentReference
+
+
+def test_document_required_props(subtests):
+    with subtests.test(msg="must contain 'coll'"):
+        with pytest.raises(ValueError,
+                           match="Data must contain the 'coll' and 'id' keys"):
+            Document({"id": 123})
+
+    with subtests.test(msg="must contain 'id'"):
+        with pytest.raises(ValueError,
+                           match="Data must contain the 'coll' and 'id' keys"):
+            Document({"coll": "hi"})
+
+
+def test_named_document_required_props(subtests):
+    with subtests.test(msg="must contain 'coll'"):
+        with pytest.raises(
+                ValueError,
+                match="Data must contain the 'coll' and 'name' keys"):
+            NamedDocument({"name": 123})
+
+    with subtests.test(msg="must contain 'id'"):
+        with pytest.raises(
+                ValueError,
+                match="Data must contain the 'coll' and 'name' keys"):
+            NamedDocument({"coll": "hi"})
+
+
+def test_ref_does_not_conflict(subtests):
+    with subtests.test(msg="Document does not conflict"):
+        d = Document({"id": 123, "coll": Module("Dogs"), "ref": "my_ref"})
+        assert d.ref == DocumentReference(Module("Dogs"), 123)
+        assert d["ref"] == "my_ref"
+
+    with subtests.test(msg="NamedDocument does not conflict"):
+        nd = NamedDocument({
+            "name": "Schema",
+            "coll": Module("Dogs"),
+            "ref": "my_ref"
+        })
+        assert nd.ref == NamedDocumentReference(Module("Dogs"), "Schema")
+        assert nd["ref"] == "my_ref"
+
+
+def test_document_equality(subtests):
+    with subtests.test(msg="Document does not equal NamedDocument"):
+        d = Document({"id": 123, "coll": Module("Dogs"), "name": "Scout"})
+        nd = NamedDocument({
+            "id": 123,
+            "coll": Module("Dogs"),
+            "name": "Scout"
+        })
+        assert d != nd

--- a/tests/unit/test_wire_protocol.py
+++ b/tests/unit/test_wire_protocol.py
@@ -147,7 +147,7 @@ def test_encode_document_references(subtests):
     doc_ref = DocumentReference.from_string("Col:123")
     with subtests.test(msg="encode/decode with @doc"):
         encoded = FaunaEncoder.encode(doc_ref)
-        assert {'@ref': {'coll': {'@mod': 'Col'}, 'id': '123'}} == encoded
+        assert {'@ref': {'coll': {'@mod': 'Col'}, 'id': 123}} == encoded
         decoded = FaunaDecoder.decode(encoded)
         assert doc_ref == decoded
 
@@ -179,7 +179,7 @@ def test_encode_documents(subtests):
         assert {"@ref": {"id": "123", "coll": {"@mod": "Dogs"}}} == encoded
         decoded = FaunaDecoder.decode(encoded)
         # refs will decode into references, not Documents
-        assert DocumentReference("Dogs", "123") == decoded
+        assert DocumentReference("Dogs", 123) == decoded
 
 
 def test_encode_named_documents(subtests):
@@ -423,7 +423,7 @@ def test_encode_fauna_type_conflicts(subtests):
             "@object": {
                 "@ref": {
                     "@ref": {
-                        "id": "123",
+                        "id": 123,
                         "coll": {
                             "@mod": "Col"
                         }

--- a/tests/unit/test_wire_protocol.py
+++ b/tests/unit/test_wire_protocol.py
@@ -147,7 +147,7 @@ def test_encode_document_references(subtests):
     doc_ref = DocumentReference.from_string("Col:123")
     with subtests.test(msg="encode/decode with @doc"):
         encoded = FaunaEncoder.encode(doc_ref)
-        assert {'@ref': {'coll': {'@mod': 'Col'}, 'id': 123}} == encoded
+        assert {'@ref': {'coll': {'@mod': 'Col'}, 'id': "123"}} == encoded
         decoded = FaunaDecoder.decode(encoded)
         assert doc_ref == decoded
 
@@ -179,12 +179,12 @@ def test_encode_documents(subtests):
         assert {"@ref": {"id": "123", "coll": {"@mod": "Dogs"}}} == encoded
         decoded = FaunaDecoder.decode(encoded)
         # refs will decode into references, not Documents
-        assert DocumentReference("Dogs", 123) == decoded
+        assert DocumentReference("Dogs", "123") == decoded
 
     with subtests.test(msg="decode document with id and name"):
         encoded = {
             "@doc": {
-                "id": 123,
+                "id": "123",
                 "coll": {
                     "@mod": "Dogs"
                 },
@@ -194,7 +194,7 @@ def test_encode_documents(subtests):
         decoded = FaunaDecoder.decode(encoded)
         # refs will decode into references, not Documents
         assert Document({
-            "id": 123,
+            "id": "123",
             "coll": Module("Dogs"),
             "name": "Scout"
         }) == decoded
@@ -441,7 +441,7 @@ def test_encode_fauna_type_conflicts(subtests):
             "@object": {
                 "@ref": {
                     "@ref": {
-                        "id": 123,
+                        "id": "123",
                         "coll": {
                             "@mod": "Col"
                         }

--- a/tests/unit/test_wire_protocol.py
+++ b/tests/unit/test_wire_protocol.py
@@ -417,9 +417,20 @@ def test_encode_date_time_conflicts(subtests):
 
 def test_encode_fauna_type_conflicts(subtests):
 
-    with subtests.test(msg="@doc conflict with doc type"):
-        test = {"@doc": DocumentReference.from_string("Col:123")}
-        expected = {"@object": {"@doc": {"@doc": "Col:123"}}}
+    with subtests.test(msg="@ref conflict with ref type"):
+        test = {"@ref": DocumentReference.from_string("Col:123")}
+        expected = {
+            "@object": {
+                "@ref": {
+                    "@ref": {
+                        "id": "123",
+                        "coll": {
+                            "@mod": "Col"
+                        }
+                    }
+                }
+            }
+        }
         encoded = FaunaEncoder.encode(test)
         assert encoded == expected
         decoded = FaunaDecoder.decode(encoded)

--- a/tests/unit/test_wire_protocol.py
+++ b/tests/unit/test_wire_protocol.py
@@ -181,6 +181,24 @@ def test_encode_documents(subtests):
         # refs will decode into references, not Documents
         assert DocumentReference("Dogs", 123) == decoded
 
+    with subtests.test(msg="decode document with id and name"):
+        encoded = {
+            "@doc": {
+                "id": 123,
+                "coll": {
+                    "@mod": "Dogs"
+                },
+                "name": "Scout"
+            }
+        }
+        decoded = FaunaDecoder.decode(encoded)
+        # refs will decode into references, not Documents
+        assert Document({
+            "id": 123,
+            "coll": Module("Dogs"),
+            "name": "Scout"
+        }) == decoded
+
 
 def test_encode_named_documents(subtests):
     with subtests.test(msg="encode/decode named document"):


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->


## Problem

Protocol changes must be handled:

New @doc, @ref, and @set tag. The @doc and @ref tags are used for documents. @doc is used when we have read a document, and @ref is used if we have not read the document.


@set will wrap a page cursor, like so:
```
{
  "@set": {
    "data": [ ... ],
    "after": "ABCD",
  }
}
```

A document with the field "name": "Foo" will look like this:
```
"@doc": {
  "id": "1234",
  "coll": { "@mod": "User" },
  "ts": { "@time": "..." },
  "name": "Foo",
}
```

After running User.byId("1234").delete(), the response will be:
```
"@ref": {
  "id": "1234",
  "coll": { "@mod": "User" },
}
```

If you stored a reference to another document, it will use the @ref tag:
```
"@doc": {
  "id": "1234567",
  "coll": { "@mod": "User" },
  "ts": { "@time": "..." },
  "books": [
    "@ref": {
      "id": "55",
      "coll": { "@mod": "Books" }
    },
    "@ref": {
      "id": "56",
      "coll": { "@mod": "Books" }
    }
  ]
}
```
So:

@ref will always have coll, and then have either id (for docs in user collections) or name (for docs in schema collections)

@doc will always have coll, ts, and then have either id (for docs in user collections) or name (for docs in schema collections)

## Solution

* Unwrap @set for now and address iterators soon.
* Introduce Document and NamedDocument. These inherit from dict to maintain the current driver feel. They will encode into @ref
* Introduce NamedDocumentReference. *DocumentReference classes will encode and decode to/from @ref


## Testing

* Added and updated some tests. More testing is needed.
