### PR TITLE
Add support for typecheck

### DIFF
--- a/fauna/client.py
+++ b/fauna/client.py
@@ -32,6 +32,7 @@ class QueryOptions:
     * query_timeout - Controls the maximum amount of time Fauna will execute your query before marking it failed.
     * query_tags - Tags to associate with the query. See `logging <https://docs.fauna.com/fauna/current/build/logs/query_log/>`_
     * traceparent - A traceparent to associate with the query. See `logging <https://docs.fauna.com/fauna/current/build/logs/query_log/>`_ Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
+    * typecheck - Enable or disable typechecking of the query before evaluation. If not set, the value configured on the Client will be used. If neither is set, Fauna will use the value of the "typechecked" flag on the database configuration.
     * additional_headers - Add/update HTTP request headers for the query. In general, this should not be necessary.
     """
 
@@ -40,6 +41,7 @@ class QueryOptions:
     query_timeout: Optional[timedelta] = None
     query_tags: Optional[Mapping[str, str]] = None
     traceparent: Optional[str] = None
+    typecheck: Optional[bool] = None
     additional_headers: Optional[Dict[str, str]] = None
 
 
@@ -54,6 +56,7 @@ class Client:
         linearized: Optional[bool] = None,
         max_contention_retries: Optional[int] = None,
         query_timeout: Optional[timedelta] = None,
+        typecheck: Optional[bool] = None,
         additional_headers: Optional[Dict[str, str]] = None,
     ):
         """Initializes a Client.
@@ -65,6 +68,7 @@ class Client:
         :param linearized: If true, unconditionally run the query as strictly serialized. This affects read-only transactions. Transactions which write will always be strictly serialized.
         :param max_contention_retries: The max number of times to retry the query if contention is encountered.
         :param query_timeout: Controls the maximum amount of time (in milliseconds) Fauna will execute your query before marking it failed.
+        :param typecheck: Enable or disable typechecking of the query before evaluation. If not set, Fauna will use the value of the "typechecked" flag on the database configuration.
         :param additional_headers: Add/update HTTP request headers for the query. In general, this should not be necessary.
         """
 
@@ -96,8 +100,11 @@ class Client:
             _Header.DriverEnv: str(_DriverEnvironment()),
         }
 
-        if linearized:
-            self._headers[Header.Linearized] = "true"
+        if typecheck is not None:
+            self._headers[Header.Typecheck] = str(typecheck).lower()
+
+        if linearized is not None:
+            self._headers[Header.Linearized] = str(linearized).lower()
 
         if max_contention_retries is not None and max_contention_retries > 0:
             self._headers[Header.MaxContentionRetries] = \
@@ -235,6 +242,8 @@ class Client:
                 headers[Header.TimeoutMs] = timeout_ms
             if opts.query_tags is not None:
                 query_tags.update(opts.query_tags)
+            if opts.typecheck is not None:
+                headers[Header.Typecheck] = str(opts.typecheck).lower()
             if opts.additional_headers is not None:
                 headers.update(opts.additional_headers)
 

--- a/fauna/headers.py
+++ b/fauna/headers.py
@@ -12,7 +12,7 @@ class Header:
     Linearized = "X-Linearized"
     MaxContentionRetries = "X-Max-Contention-Retries"
     TimeoutMs = "X-Timeout-Ms"
-    TypeChecking = "X-Type-Checking"
+    Typecheck = "X-Typecheck"
     Tags = "X-Query-Tags"
     Traceparent = "Traceparent"
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,38 +1,8 @@
 from datetime import date, datetime, timezone, timedelta
-from random import randint
-from typing import Mapping
 
 import pytest
 
 from fauna import Module, DocumentReference
-
-
-@pytest.fixture
-def linearized() -> bool:
-    return True
-
-
-@pytest.fixture
-def tags() -> Mapping[str, str]:
-    return {
-        "hello": "world",
-        "testing": "foobar",
-    }
-
-
-@pytest.fixture
-def query_timeout_ms() -> float:
-    return 5000.0
-
-
-@pytest.fixture
-def traceparent() -> str:
-    return "happy-little-fox"
-
-
-@pytest.fixture
-def max_contention_retries() -> int:
-    return 5
 
 
 @pytest.fixture

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -105,6 +105,7 @@ def test_query_options_set(httpx_mock: HTTPXMock):
         "hello": "world",
         "testing": "foobar",
     }
+    additional_headers = {"additional": "header"}
 
     def validate_headers(request: httpx.Request):
         """
@@ -116,6 +117,7 @@ def test_query_options_set(httpx_mock: HTTPXMock):
         assert request.headers[Header.Typecheck] == str(typecheck).lower()
         assert request.headers[Header.MaxContentionRetries] == f"{max_contention_retries}"  # yapf: disable
         assert request.headers[Header.Tags] == "project=teapot&hello=world&testing=foobar"  # yapf: disable
+        assert request.headers["additional"] == "header"
 
         return httpx.Response(
             status_code=200,
@@ -139,6 +141,7 @@ def test_query_options_set(httpx_mock: HTTPXMock):
                 traceparent=traceparent,
                 max_contention_retries=max_contention_retries,
                 typecheck=typecheck,
+                additional_headers=additional_headers,
             ),
         )
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -49,8 +49,10 @@ def test_client_with_args():
     timeout = timedelta(seconds=900)
     linearized = True
     max_retries = 100
-    track = False
     tags = {"tag_name": "tag_value"}
+    typecheck = True
+    additional_headers = {"foo": "bar"}
+
     http_client = HTTPXClient(httpx.Client())
 
     client = Client(
@@ -61,6 +63,8 @@ def test_client_with_args():
         max_contention_retries=max_retries,
         query_tags=tags,
         http_client=http_client,
+        typecheck=typecheck,
+        additional_headers=additional_headers,
     )
 
     assert client._auth.secret == secret
@@ -68,6 +72,10 @@ def test_client_with_args():
     assert client._query_timeout_ms == 900000
     assert client._query_tags == tags
     assert client._session == http_client
+    assert client._headers[Header.Typecheck] == "true"
+    assert client._headers[Header.Linearized] == "true"
+    assert client._headers[Header.MaxContentionRetries] == "100"
+    assert client._headers["foo"] == "bar"
 
 
 def test_get_set_transaction_time():
@@ -86,27 +94,29 @@ def test_get_query_timeout():
     assert c.get_query_timeout() == timedelta(minutes=1)
 
 
-def test_query_options_set(
-    httpx_mock: HTTPXMock,
-    linearized: bool,
-    query_timeout_ms: float,
-    traceparent: str,
-    tags: Mapping[str, str],
-    max_contention_retries: int,
-):
+def test_query_options_set(httpx_mock: HTTPXMock):
+
+    typecheck = True
+    linearized = True
+    query_timeout_ms = 5000.0
+    traceparent = "happy-little-fox"
+    max_contention_retries = 5
+    tags = {
+        "hello": "world",
+        "testing": "foobar",
+    }
 
     def validate_headers(request: httpx.Request):
         """
         Validate each of the associated Headers are set on the request
         """
         assert request.headers[Header.Linearized] == str(linearized).lower()
-        # being explicit to not figure out encoding a Mapping in the test
-        assert request.headers[Header.Tags] == \
-            "project=teapot&hello=world&testing=foobar"
         assert request.headers[Header.TimeoutMs] == f"{query_timeout_ms}"
         assert request.headers[Header.Traceparent] == traceparent
-        assert request.headers[Header.MaxContentionRetries] \
-            == f"{max_contention_retries}"
+        assert request.headers[Header.Typecheck] == str(typecheck).lower()
+        assert request.headers[Header.MaxContentionRetries] == f"{max_contention_retries}"  # yapf: disable
+        assert request.headers[Header.Tags] == "project=teapot&hello=world&testing=foobar"  # yapf: disable
+
         return httpx.Response(
             status_code=200,
             json={"data": "mocked"},
@@ -128,6 +138,7 @@ def test_query_options_set(
                 query_timeout=timedelta(milliseconds=query_timeout_ms),
                 traceparent=traceparent,
                 max_contention_retries=max_contention_retries,
+                typecheck=typecheck,
             ),
         )
 
@@ -223,14 +234,6 @@ def test_client_headers(
             )
             c.query(fql("just a mock"))
 
-        with subtests.test("should allow custom header"):
-            c = Client(http_client=http_client)
-            expected = {"yellow": "submarine"}
-            c.query(
-                fql("just a mock"),
-                QueryOptions(additional_headers=expected),
-            )
-
         with subtests.test("Linearized should be set on Client"):
             c = Client(
                 http_client=http_client,
@@ -238,14 +241,6 @@ def test_client_headers(
             )
             expected = {Header.Linearized: "true"}
             c.query(fql("just a mock"))
-
-        with subtests.test("Linearized should be set on Query"):
-            expected = {Header.Linearized: "true"}
-            c = Client(http_client=http_client)
-            c.query(
-                fql("just a mock"),
-                QueryOptions(linearized=True),
-            )
 
         with subtests.test("Max Contention Retries on Client"):
             count = 5
@@ -258,21 +253,11 @@ def test_client_headers(
             expected = {Header.MaxContentionRetries: f"{count}"}
             c.query(fql("just a mock"))
 
-        with subtests.test("Max Contention Retries on Query"):
-            count = 5
-            expected = {Header.MaxContentionRetries: f"{count}"}
-            c = Client(http_client=http_client)
-            c.query(
-                fql("just a mock"),
-                QueryOptions(max_contention_retries=count),
+        with subtests.test("Typecheck on Client"):
+            c = Client(
+                http_client=http_client,
+                typecheck=True,
             )
 
-        # doesn't make sense to be set on the Client
-        with subtests.test("Should have a Traceparent"):
-            traceparent = "moshi-moshi"
-            expected = {Header.Traceparent: traceparent}
-            c = Client(http_client=http_client)
-            c.query(
-                fql("just a mock"),
-                QueryOptions(traceparent=traceparent),
-            )
+            expected = {Header.Typecheck: "true"}
+            c.query(fql("just a mock"))


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem

We need to expose an option to enable or disable typechecking at the Client and the Query. The default should be that x-typecheck is unset.

## Solution

* Add a typecheck arg to the Client used to set the correct header
* Add a typecheck arg to QueryOptions used to set the correct header
* Some misc cleanup 

## Testing

Extended unit tests.
