### PR TITLE
Add support for constraint failures

### DIFF
--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -1,6 +1,7 @@
 import pytest
 
 from fauna import fql
+from fauna.errors import QueryRuntimeError, ConstraintFailure
 from fauna.response import Stat
 
 
@@ -11,7 +12,7 @@ def test_query(subtests, client):
 
         assert res.status_code == 200
         assert res.data == float(5123.0)
-        assert res.stat(Stat.ComputeOps) > 0
+        assert res.stats[Stat.ComputeOps] > 0
         assert res.traceparent != ""
         assert res.summary == ""
 
@@ -24,11 +25,27 @@ def test_query(subtests, client):
     with subtests.test(msg="stats"):
         res = client.query(fql("Math.abs(-5.123e3)"))
         with subtests.test(msg="valid stat"):
-            assert res.stat(Stat.ComputeOps) > 0
+            assert res.stats[Stat.ComputeOps] > 0
         with subtests.test(msg="invalid stat"):
             with pytest.raises(Exception) as e:
-                assert res.stat("silly") == 0
+                assert res.stats["silly"] == 0
             assert e.type == KeyError
         with subtests.test(msg="manual stat"):
             # prove that we can use a plain string
-            assert res.stat("read_ops") == 0
+            assert res.stats["read_ops"] == 0
+
+
+def test_query_with_constraint_failure(client):
+    with pytest.raises(QueryRuntimeError) as e:
+        client.query(
+            fql('Function.create({"name": "double", "body": "x => x * 2"})'))
+
+    assert e.value.constraint_failures == [
+        ConstraintFailure(message="The identifier `double` is reserved.",
+                          name=None,
+                          paths=[["name"]]),
+    ]
+    assert e.value.status_code == 400
+    assert e.value.code == "constraint_failure"
+    assert e.value.message == "Failed to create document in collection Function."
+    assert len(e.value.summary) > 0

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -9,6 +9,7 @@ from pytest_httpx import HTTPXMock
 import fauna
 from fauna import Client, HTTPXClient, Header, fql
 from fauna.client import QueryOptions
+from fauna.errors import QueryCheckError, ProtocolError, QueryRuntimeError
 
 
 def test_client_defaults(monkeypatch):
@@ -276,3 +277,124 @@ def test_client_headers(
                 fql("just a mock"),
                 QueryOptions(traceparent=traceparent),
             )
+
+
+def test_error_query_check_error(subtests, httpx_mock: HTTPXMock):
+
+    def callback(_: httpx.Request):
+        return httpx.Response(
+            status_code=400,
+            json={
+                "error": {
+                    "code": "invalid_query",
+                    "message": "did not jump"
+                }
+            },
+        )
+
+    httpx_mock.add_callback(callback)
+
+    with httpx.Client() as mockClient:
+        http_client = HTTPXClient(mockClient)
+        c = Client(http_client=http_client)
+        with pytest.raises(QueryCheckError, match="did not jump"):
+            c.query(fql("the quick brown fox"))
+
+
+def test_error_query_runtime_error(subtests, httpx_mock: HTTPXMock):
+
+    def callback(_: httpx.Request):
+        return httpx.Response(
+            status_code=400,
+            json={"error": {
+                "code": "anything",
+                "message": "did not jump"
+            }},
+        )
+
+    httpx_mock.add_callback(callback)
+
+    with httpx.Client() as mockClient:
+        http_client = HTTPXClient(mockClient)
+        c = Client(http_client=http_client)
+        with pytest.raises(QueryRuntimeError, match="did not jump"):
+            c.query(fql("the quick brown fox"))
+
+
+def test_error_protocol_error_missing_error_key(subtests,
+                                                httpx_mock: HTTPXMock):
+
+    def callback(_: httpx.Request):
+        return httpx.Response(
+            status_code=400,
+            json={"data": "jumped"},
+        )
+
+    httpx_mock.add_callback(callback)
+
+    with httpx.Client() as mockClient:
+        http_client = HTTPXClient(mockClient)
+        c = Client(http_client=http_client)
+        err = "400: Unexpected response\nResponse is in an unknown format: \n{'data': 'jumped'}"
+        with pytest.raises(ProtocolError, match=err):
+            c.query(fql("the quick brown fox"))
+
+
+def test_error_protocol_error_missing_error_code(subtests,
+                                                 httpx_mock: HTTPXMock):
+
+    def callback(_: httpx.Request):
+        return httpx.Response(
+            status_code=400,
+            json={"error": {
+                "message": "boo"
+            }},
+        )
+
+    httpx_mock.add_callback(callback)
+
+    with httpx.Client() as mockClient:
+        http_client = HTTPXClient(mockClient)
+        c = Client(http_client=http_client)
+        err = "400: Unexpected response\nResponse is in an unknown format: \n{'error': {'message': 'boo'}}"
+        with pytest.raises(ProtocolError, match=err):
+            c.query(fql("the quick brown fox"))
+
+
+def test_error_protocol_error_missing_error_message(subtests,
+                                                    httpx_mock: HTTPXMock):
+
+    def callback(_: httpx.Request):
+        return httpx.Response(
+            status_code=400,
+            json={"error": {
+                "code": "boo"
+            }},
+        )
+
+    httpx_mock.add_callback(callback)
+
+    with httpx.Client() as mockClient:
+        http_client = HTTPXClient(mockClient)
+        c = Client(http_client=http_client)
+        err = "400: Unexpected response\nResponse is in an unknown format: \n{'error': {'code': 'boo'}}"
+        with pytest.raises(ProtocolError, match=err):
+            c.query(fql("the quick brown fox"))
+
+
+def test_error_protocol_data_missing(subtests, httpx_mock: HTTPXMock):
+
+    def callback(_: httpx.Request):
+        return httpx.Response(
+            status_code=200,
+            json={},
+        )
+
+    httpx_mock.add_callback(callback)
+
+    with httpx.Client() as mockClient:
+        http_client = HTTPXClient(mockClient)
+        c = Client(http_client=http_client)
+        err = "200: Unexpected response\nResponse is in an unknown format: \n{}"
+        with pytest.raises(ProtocolError, match=err):
+            c.query(fql("the quick brown fox"))


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem

We don't support constraint_failures from the QueryFailure wire protocol.

## Solution

Error handling probably deserves more love soon, but I think this is an improvment.

* Add support for constraint_failures. For now, added ConstraintFailure dataclass to errors.py file, although the wire_protocol.py should be renamed to encoding.py and we should probably encapsulate wire wire protocol concepts in a wire protocol file..
* Separates protocol error handling from the rest for the moment and be strict with query success and failure
* Sneak in a quick stats contract update
* Add a few unit tests
* Add an integ test for the constraint failures


## Testing

Added new unit tests and a new integ test
