### PR TITLE
Improve Document models

### DIFF
--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,102 +1,75 @@
-import pytest
+from datetime import datetime
 
-from fauna import Document, NamedDocument, Module, DocumentReference, NamedDocumentReference
+from fauna import Document, NamedDocument, Module
+
+fixed_datetime = datetime.fromisoformat("2023-03-17")
 
 
 def test_document_required_props(subtests):
     with subtests.test(msg="accepts 'id' str and 'coll' str"):
-        Document({"id": "123", "coll": "hi"})
+        Document(id="123", coll="hi", ts=fixed_datetime)
 
     with subtests.test(msg="accepts 'id' str and 'coll' module"):
-        Document({"id": "123", "coll": Module("hi")})
+        Document(id="123", coll=Module("hi"), ts=fixed_datetime)
 
-    with subtests.test(msg="must contain 'coll'"):
-        with pytest.raises(ValueError,
-                           match="Data must contain the 'coll' and 'id' keys"):
-            Document({"id": "123"})
 
-    with subtests.test(msg="must contain 'id'"):
-        with pytest.raises(ValueError,
-                           match="Data must contain the 'coll' and 'id' keys"):
-            Document({"coll": "hi"})
-
-    with subtests.test(msg="'coll' must be a str or module"):
-        with pytest.raises(
-                TypeError,
-                match=
-                "'coll' should be of type Module or str, but was <class 'int'>"
-        ):
-            Document({"id": "123", "coll": 123})
+def test_document_unwrap(subtests):
+    with subtests.test(msg="accepts 'id' str and 'coll' str"):
+        d = Document(id="123",
+                     coll="Dogs",
+                     ts=fixed_datetime,
+                     data={"name": "Scout"})
+        unwrapped = dict(d)
+        assert unwrapped == {"name": "Scout"}
 
 
 def test_named_document_required_props(subtests):
     with subtests.test(msg="accepts 'name' str and 'coll' str"):
-        NamedDocument({"name": "Python", "coll": "hi"})
+        NamedDocument(name="Python", coll="hi", ts=fixed_datetime)
 
     with subtests.test(msg="accepts 'name' str and 'coll' module"):
-        NamedDocument({"name": "Python", "coll": Module("hi")})
-
-    with subtests.test(msg="must contain 'coll'"):
-        with pytest.raises(
-                ValueError,
-                match="Data must contain the 'coll' and 'name' keys"):
-            NamedDocument({"name": "123"})
-
-    with subtests.test(msg="must contain 'id'"):
-        with pytest.raises(
-                ValueError,
-                match="Data must contain the 'coll' and 'name' keys"):
-            NamedDocument({"coll": "hi"})
-
-    with subtests.test(msg="'coll' must be a str or module"):
-        with pytest.raises(
-                TypeError,
-                match=
-                "'coll' should be of type Module or str, but was <class 'int'>"
-        ):
-            NamedDocument({"name": "Python", "coll": 123})
-
-
-def test_ref_does_not_conflict(subtests):
-    with subtests.test(msg="Document does not conflict"):
-        d = Document({"id": "123", "coll": Module("Dogs"), "ref": "my_ref"})
-        assert d.ref == DocumentReference(Module("Dogs"), "123")
-        assert d["ref"] == "my_ref"
-
-    with subtests.test(msg="NamedDocument does not conflict"):
-        nd = NamedDocument({
-            "name": "Schema",
-            "coll": Module("Dogs"),
-            "ref": "my_ref"
-        })
-        assert nd.ref == NamedDocumentReference(Module("Dogs"), "Schema")
-        assert nd["ref"] == "my_ref"
+        NamedDocument(name="Python", coll="hi", ts=fixed_datetime)
 
 
 def test_document_equality(subtests):
     with subtests.test(msg="Document does not equal NamedDocument"):
-        d = Document({"id": "123", "coll": Module("Dogs"), "name": "Scout"})
-        nd = NamedDocument({
-            "id": "123",
-            "coll": Module("Dogs"),
-            "name": "Scout"
-        })
+        d = Document(id="123",
+                     coll="Dogs",
+                     ts=fixed_datetime,
+                     data={"name": "Scout"})
+        nd = NamedDocument(name="Scout",
+                           coll="Dogs",
+                           ts=fixed_datetime,
+                           data={"id": "123"})
         assert d != nd
 
     with subtests.test(msg="Document equals Document"):
-        d1 = Document({"id": "123", "coll": Module("Dogs"), "name": "Scout"})
-        d2 = Document({"id": "123", "coll": Module("Dogs"), "name": "Scout"})
+        d1 = Document(id="123",
+                      coll="Dogs",
+                      ts=fixed_datetime,
+                      data={"name": "Scout"})
+        d2 = Document(id="123",
+                      coll="Dogs",
+                      ts=fixed_datetime,
+                      data={"name": "Scout"})
         assert d1 == d2
 
     with subtests.test(msg="NamedDocument equals NamedDocument"):
-        nd1 = NamedDocument({
-            "id": "123",
-            "coll": Module("Dogs"),
-            "name": "Scout"
-        })
-        nd2 = NamedDocument({
-            "id": "123",
-            "coll": Module("Dogs"),
-            "name": "Scout"
-        })
+        nd1 = NamedDocument(name="Scout",
+                            coll="Dogs",
+                            ts=fixed_datetime,
+                            data={"id": "123"})
+        nd2 = NamedDocument(name="Scout",
+                            coll="Dogs",
+                            ts=fixed_datetime,
+                            data={"id": "123"})
         assert nd1 == nd2
+
+    with subtests.test(msg="Equality failure with other class does not throw"):
+        d1 = Document(id="123",
+                      coll="Dogs",
+                      ts=fixed_datetime,
+                      data={"name": "Scout"})
+        other = 123
+        _ = d1 == other
+        _ = d1 != other


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem

The previous model mingled `id`, `coll`, and `ts` with user data.


## Solution

Instead, store `id`, `coll`, and `ts` on top-level properties, and rest in the backing collection. This provides clearer delineation between document props and user-stored data.


## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

Updated and added tests.
