### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,6 @@ jobs:
           - "3.11"
           - "3.10"
           - "3.9"
-          - "3.8"
         fauna-docker-service:
           - name: "fauna/faunadb:latest"
             host: "core"

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,6 @@ Compatibility
 
 The following versions of Python are supported:
 
-* Python 3.8
 * Python 3.9
 * Python 3.10
 * Python 3.11


### PR DESCRIPTION
We're going to proceed without explicit Python 3.8 support