### PR TITLE
Fixups for http client rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ build
 dist
 docs/
 htmlcov/
-faunadb.egg-info
+fauna.egg-info
 venv
 venv3
 results/

--- a/fauna/http/http_client.py
+++ b/fauna/http/http_client.py
@@ -1,11 +1,7 @@
 import abc
-import json
-from typing import Optional, Iterator, Mapping, Any
+
+from typing import Iterator, Mapping, Any
 from dataclasses import dataclass
-
-import httpx
-
-from fauna.errors import ClientError, NetworkError
 
 
 @dataclass(frozen=True)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "Operating System :: Unix",
     ],
     keywords="faunadb fauna",
-    packages=["fauna"],
+    packages=["fauna", "fauna.http"],
     install_requires=requires,
     extras_require=extras_require,
 )


### PR DESCRIPTION
## Problem

When testing against Vercel functions I ran into:

```
ModuleNotFoundError: No module named 'fauna.http'
```

## Solution

- Added `fauna.http` to packages in `setup.py`
- Removed unused imports
- Updated `.gitignore`

## Result

http submodule is included in bundled module

## Testing

I'm at least getting a 403 now at Vercel until my new test account user is added to the beta access list 😉 
