### PR TITLE
Add __str__ to Query Interpolation

### DIFF
--- a/fauna/query_builder.py
+++ b/fauna/query_builder.py
@@ -67,6 +67,13 @@ class QueryInterpolation:
         """The list of stored Fragments"""
         return self._fragments
 
+    def __str__(self) -> str:
+        res = ""
+        for f in self._fragments:
+            res += str(f.get())
+
+        return res
+
 
 def fql(query: str, **kwargs: Any) -> QueryInterpolation:
     """Creates a QueryInterpolation - capable of performing query composition and simple querying. It can accept a

--- a/tests/unit/test_query_builder.py
+++ b/tests/unit/test_query_builder.py
@@ -41,6 +41,7 @@ def test_query_builder_supports_fauna_interpolated_strings():
     ])
 
     assert_builders(expected, actual)
+    assert str(actual) == "let age = 5\n\"Alice is #{age} years old.\""
 
 
 def test_query_builder_values(subtests):
@@ -59,10 +60,13 @@ def test_query_builder_sub_queries(subtests):
     with subtests.test(msg="single subquery with object"):
         user = {"name": "Dino", "age": 0, "birthdate": date(2023, 2, 24)}
         inner = fql("""let x = ${my_var}""", my_var=user)
-        actual = fql("${inner}\nx { .name }", inner=inner)
+        actual = fql("${inner}\nx { name }", inner=inner)
         expected = QueryInterpolation([
             ValueFragment(inner),
-            LiteralFragment("\nx { .name }"),
+            LiteralFragment("\nx { name }"),
         ])
 
         assert_builders(expected, actual)
+        assert str(actual) == "let x = " \
+               + "{'name': 'Dino', 'age': 0, 'birthdate': datetime.date(2023, 2, 24)}\n" \
+               + "x { name }"


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem

We don't have a str repr for a Query Interpolation.

## Solution

Add a str repr to help users preview the full query in the simplest manner possible.

## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

Added str checks to a couple tests.
