### PR TITLE
Run pytest commands directly inside pipeline

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -7,4 +7,6 @@ apk add --update make
 pip install . .[test]
 pip install codecov
 
-make test
+python -m coverage run -m pytest tests/unit
+python -m coverage run -m pytest tests/integration
+python -m coverage report -m


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->


## Problem

We can't invoke python inside make inside the pipeline.

## Solution

Instead of troubleshooting this now, just call coverage/pytest directly.

