### PR TITLE
Ping faunadb until it's ready

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2,10 +2,25 @@
 
 set -eou
 
-apk add --update make
+apk add --update make curl
 
 pip install . .[test]
 pip install codecov
+
+attempt_counter=0
+max_attempts=100
+
+until $(curl -m 1 --output /dev/null --silent --head --fail $FAUNA_ENDPOINT/ping); do
+  if [ ${attempt_counter} -eq ${max_attempts} ];then
+    echo ""
+    echo "Max attempts reached to $FAUNA_ENDPOINT/ping"
+    exit 1
+  fi
+
+  printf '.'
+  attempt_counter=$(($attempt_counter+1))
+  sleep 5
+done
 
 python -m coverage run -m pytest tests/unit
 python -m coverage run -m pytest tests/integration


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem

We're running the integration tests in the pipeline before faunadb is ready.

## Solution

Ping/sleep until we're ready.

## Testing

`make docker-test`
