### PR TITLE
Add __repr__ to models

### DIFF
--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -10,7 +10,7 @@ from fauna.client.headers import _DriverEnvironment, _Header, _Auth, Header
 from fauna.http.http_client import HTTPClient
 from fauna.query.query_builder import QueryInterpolation
 from fauna.client.utils import _Environment, LastTxnTs
-from fauna.encoding import FaunaEncoder
+from fauna.encoding import FaunaEncoder, FaunaDecoder
 from fauna.client.wire_protocol import QuerySuccess, ConstraintFailure, QueryInfo, QueryTags
 
 DefaultHttpConnectTimeout = timedelta(seconds=5)
@@ -279,7 +279,27 @@ class Client:
             if "txn_ts" in response_json:
                 self.set_last_txn_ts(int(response_json["txn_ts"]))
 
-            return QuerySuccess(response_json, headers)
+            stats = response_json["stats"] if "stats" in response_json else None
+            summary = response_json[
+                "summary"] if "summary" in response_json else None
+            query_tags = QueryTags.decode(
+                response_json["query_tags"]
+            ) if "query_tags" in response_json else None
+            txn_ts = response_json[
+                "txn_ts"] if "txn_ts" in response_json else None
+            traceparent = headers.get("traceparent", None)
+            static_type = response_json[
+                "static_type"] if "static_type" in response_json else None
+
+            return QuerySuccess(
+                data=FaunaDecoder.decode(response_json["data"]),
+                query_tags=query_tags,
+                static_type=static_type,
+                stats=stats,
+                summary=summary,
+                traceparent=traceparent,
+                txn_ts=txn_ts,
+            )
 
     def _check_protocol(self, response_json: Any, status_code):
         # TODO: Logic to validate wire protocol belongs elsewhere.
@@ -311,7 +331,8 @@ class Client:
         message = err["message"]
         constraint_failures: Optional[List[ConstraintFailure]] = None
         query_info = QueryInfo(
-            query_tags=body["query_tags"] if "query_tags" in body else None,
+            query_tags=QueryTags.decode(body["query_tags"])
+            if "query_tags" in body else None,
             stats=body["stats"] if "stats" in body else None,
             txn_ts=body["txn_ts"] if "txn_ts" in body else None,
             summary=body["summary"] if "summary" in body else None,

--- a/fauna/encoding/encoder.py
+++ b/fauna/encoding/encoder.py
@@ -135,7 +135,7 @@ class FaunaEncoder:
 
     @staticmethod
     def from_mod(obj: Module):
-        return {"@mod": str(obj)}
+        return {"@mod": obj.name}
 
     @staticmethod
     def from_dict(obj: Any):

--- a/fauna/query/models.py
+++ b/fauna/query/models.py
@@ -16,8 +16,8 @@ class Module:
     def __init__(self, name: str):
         self.name = name
 
-    def __str__(self):
-        return self.name
+    def __repr__(self):
+        return f"{self.__class__.__name__}(name={repr(self.name)})"
 
     def __eq__(self, other):
         return isinstance(other, Module) and str(self) == str(other)
@@ -29,6 +29,10 @@ class Module:
 class BaseReference:
     _collection: Module
 
+    @property
+    def coll(self) -> Module:
+        return self._collection
+
     def __init__(self, coll: Union[str, Module]):
         if isinstance(coll, Module):
             self._collection = coll
@@ -39,16 +43,24 @@ class BaseReference:
                 f"'coll' should be of type Module or str, but was {type(coll)}"
             )
 
-    @property
-    def coll(self) -> Module:
-        return self._collection
+    def __repr__(self):
+        return f"{self.__class__.__name__}(coll={repr(self._collection)})"
+
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and str(self) == str(other)
 
 
 class DocumentReference(BaseReference):
     """A class representing a reference to a :class:`Document` stored in Fauna.
     """
 
-    _id: str
+    @property
+    def id(self) -> str:
+        """The ID for the :class:`Document`. Valid IDs are 64-bit integers, stored as strings.
+
+        :rtype: str
+        """
+        return self._id
 
     def __init__(self, coll: Union[str, Module], id: str):
         super().__init__(coll)
@@ -61,19 +73,8 @@ class DocumentReference(BaseReference):
     def __hash__(self):
         hash((type(self), self._collection, self._id))
 
-    def __str__(self):
-        return f"{self._collection}:{self._id}"
-
-    def __eq__(self, other):
-        return isinstance(other, type(self)) and str(self) == str(other)
-
-    @property
-    def id(self) -> str:
-        """The ID for the :class:`Document`. Valid IDs are 64-bit integers, stored as strings.
-
-        :rtype: str
-        """
-        return self._id
+    def __repr__(self):
+        return f"{self.__class__.__name__}(id={repr(self._id)},coll={repr(self._collection)})"
 
     @staticmethod
     def from_string(ref: str):
@@ -87,7 +88,13 @@ class NamedDocumentReference(BaseReference):
     """A class representing a reference to a :class:`NamedDocument` stored in Fauna.
     """
 
-    _name: str
+    @property
+    def name(self) -> str:
+        """The name of the :class:`NamedDocument`.
+
+        :rtype: str
+        """
+        return self._name
 
     def __init__(self, coll: Union[str, Module], name: str):
         super().__init__(coll)
@@ -101,19 +108,8 @@ class NamedDocumentReference(BaseReference):
     def __hash__(self):
         hash((type(self), self._collection, self._name))
 
-    def __str__(self):
-        return f"{self._collection}:{self._name}"
-
-    def __eq__(self, other):
-        return isinstance(other, type(self)) and str(self) == str(other)
-
-    @property
-    def name(self) -> str:
-        """The name of the :class:`NamedDocument`.
-
-        :rtype: str
-        """
-        return self._name
+    def __repr__(self):
+        return f"{self.__class__.__name__}(name={repr(self._name)},coll={repr(self._collection)})"
 
 
 class BaseDocument(Mapping):
@@ -206,6 +202,15 @@ class Document(BaseDocument):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __repr__(self):
+        kvs = ",".join([f"{repr(k)}:{repr(v)}" for k, v in self.items()])
+
+        return f"{self.__class__.__name__}(" \
+               f"id={repr(self.id)}," \
+               f"coll={repr(self.coll)}," \
+               f"ts={repr(self.ts)}," \
+               f"data={{{kvs}}})"
+
 
 class NamedDocument(BaseDocument):
     """A class representing a named document stored in Fauna. Examples of named documents include Collection
@@ -262,3 +267,12 @@ class NamedDocument(BaseDocument):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    def __repr__(self):
+        kvs = ",".join([f"{repr(k)}:{repr(v)}" for k, v in self.items()])
+
+        return f"{self.__class__.__name__}(" \
+               f"name={repr(self.name)}," \
+               f"coll={repr(self.coll)}," \
+               f"ts={repr(self.ts)}," \
+               f"data={{{kvs}}})"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,8 +1,60 @@
-from datetime import datetime
+import datetime
 
-from fauna.query.models import Document, Module, NamedDocument
+from fauna.query.models import Document, Module, NamedDocument, BaseReference, DocumentReference, NamedDocumentReference
 
-fixed_datetime = datetime.fromisoformat("2023-03-17")
+fixed_datetime = datetime.datetime.fromisoformat("2023-03-17")
+
+
+def test_module_repr():
+    m = Module("mod_name")
+    assert repr(m) == "Module(name='mod_name')"
+    assert eval(repr(m)) == m
+
+
+def test_base_reference_repr():
+    br = BaseReference(Module("mod"))
+    assert repr(br) == "BaseReference(coll=Module(name='mod'))"
+    assert eval(repr(br)) == br
+
+
+def test_doc_reference_repr():
+    dr = DocumentReference(id="123", coll=Module("mod"))
+    assert repr(dr) == "DocumentReference(id='123',coll=Module(name='mod'))"
+    assert eval(repr(dr)) == dr
+
+
+def test_named_doc_reference_repr():
+    dr = NamedDocumentReference(name="Def", coll=Module("MyCol"))
+    assert repr(
+        dr) == "NamedDocumentReference(name='Def',coll=Module(name='MyCol'))"
+    assert eval(repr(dr)) == dr
+
+
+def test_doc_repr():
+    doc = Document(id="123",
+                   coll="MyCol",
+                   ts=fixed_datetime,
+                   data={"foo": "bar"})
+    assert repr(doc) == "Document(id='123'," \
+                        "coll=Module(name='MyCol')," \
+                        "ts=datetime.datetime(2023, 3, 17, 0, 0)," \
+                        "data={'foo':'bar'})"
+    assert eval(repr(doc)) == doc
+
+
+def test_named_doc_repr():
+    doc = NamedDocument(name="Things",
+                        coll="Foo",
+                        ts=fixed_datetime,
+                        data={
+                            "foo": "bar",
+                            "my_date": fixed_datetime
+                        })
+    assert repr(doc) == "NamedDocument(name='Things'," \
+                        "coll=Module(name='Foo')," \
+                        "ts=datetime.datetime(2023, 3, 17, 0, 0)," \
+                        "data={'foo':'bar','my_date':datetime.datetime(2023, 3, 17, 0, 0)})"
+    assert eval(repr(doc)) == doc
 
 
 def test_document_required_props(subtests):

--- a/tests/unit/test_wire_protocol.py
+++ b/tests/unit/test_wire_protocol.py
@@ -1,0 +1,50 @@
+from fauna.client import QuerySuccess, QueryInfo
+
+
+def test_query_success_repr():
+    qs = QuerySuccess(
+        data={'foo': 'bar'},
+        query_tags={'tag': 'value'},
+        static_type=None,
+        stats={'stat': 1},
+        summary="human readable",
+        traceparent=None,
+        txn_ts=123,
+    )
+
+    assert repr(qs) == "QuerySuccess(query_tags={'tag': 'value'}," \
+                       "static_type=None," \
+                       "stats={'stat': 1}," \
+                       "summary='human readable'," \
+                       "traceparent=None," \
+                       "txn_ts=123," \
+                       "data={'foo': 'bar'})"
+
+    evaluated: QuerySuccess = eval(repr(qs))
+    assert evaluated.txn_ts == qs.txn_ts
+    assert evaluated.traceparent == qs.traceparent
+    assert evaluated.query_tags == qs.query_tags
+    assert evaluated.data == qs.data
+    assert evaluated.static_type == qs.static_type
+    assert evaluated.summary == qs.summary
+    assert evaluated.stats == qs.stats
+
+
+def test_query_info_repr():
+    qi = QueryInfo(
+        query_tags={'tag': 'value'},
+        stats={'stat': 1},
+        summary="human readable",
+        txn_ts=123,
+    )
+
+    assert repr(qi) == "QueryInfo(query_tags={'tag': 'value'}," \
+                       "stats={'stat': 1}," \
+                       "summary='human readable'," \
+                       "txn_ts=123)"
+
+    evaluated: QueryInfo = eval(repr(qi))
+    assert evaluated.txn_ts == qi.txn_ts
+    assert evaluated.query_tags == qi.query_tags
+    assert evaluated.summary == qi.summary
+    assert evaluated.stats == qi.stats


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-3677

## Problem

The models to represent the query response/info and documents, refs, and modules lack a `__repr__` implementation. This makes it difficult to developers to easily print their object.

## Solution

* Implement `__repr__` for each custom class
* Revised QuerySuccess with stronger contract
* Added a few missing docstrings
* Removed a few `__str__` implementations. These require a bit more thought

## Testing

Added new tests and ran `make docker-test`


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

