### PR TITLE
Remove print() statement in client init

### DIFF
--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -77,8 +77,6 @@ class Client:
         else:
             self._endpoint = endpoint
 
-        print(f"endpoint set to {self._endpoint}")
-
         if secret is None:
             self._auth = _Auth(_Environment.EnvFaunaSecret())
         else:


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-3676

## Problem

We have a left over print statement in `Client.__init__` 

## Solution

Remove it


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

