### PR TITLE
Check query arg type and raise

### DIFF
--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -198,7 +198,13 @@ class Client:
         :raises ProtocolError: HTTP error not from Fauna
         :raises ServiceError: Fauna returned an error
         :raises ValueError: Encoding and decoding errors
+        :raises TypeError: Invalid param types
         """
+
+        if not isinstance(fql, QueryInterpolation):
+            err_msg = f"'fql' must be a QueryInterpolation but was a {type(fql)}. You can build a " \
+                       f"QueryInterpolation by calling fauna.fql()"
+            raise TypeError(err_msg)
 
         try:
             encoded_query: Mapping[str, Any] = FaunaEncoder.encode(fql)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -406,3 +406,13 @@ def test_error_protocol_data_missing(subtests, httpx_mock: HTTPXMock):
         err = "200: Unexpected response\nResponse is in an unknown format: \n{}"
         with pytest.raises(ProtocolError, match=err):
             c.query(fql("the quick brown fox"))
+
+
+def test_call_query_with_string():
+    c = Client()
+    with pytest.raises(
+            TypeError,
+            match=
+            "'fql' must be a QueryInterpolation but was a <class 'str'>. You can build a QueryInterpolation by "
+            "calling fauna.fql()"):
+        c.query("fake")  # type: ignore


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-3681

## Problem

We don't check the query argument type at runtime. This can result in confusing error messages.

## Solution

Check that the type of `fql` arg is `QueryInterpolation`.

## Testing

Added test


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

