### PR TITLE
Emit client error instead of json error

### DIFF
--- a/fauna/http/httpx_client.py
+++ b/fauna/http/httpx_client.py
@@ -25,8 +25,8 @@ class HTTPXResponse(HTTPResponse):
             return json.loads(decoded)
         except (JSONDecodeError, UnicodeDecodeError) as e:
             raise ClientError(
-                f"Unable to decode response from endpoint {self._r.request.url}. Check that your "
-                f"endpoint is valid.") from e
+                f"Unable to decode response from endpoint {self._r.request.url}. Check that your endpoint is valid."
+            ) from e
 
     def status_code(self) -> int:
         return self._r.status_code

--- a/fauna/http/httpx_client.py
+++ b/fauna/http/httpx_client.py
@@ -1,4 +1,5 @@
 import json
+from json import JSONDecodeError
 from typing import Mapping, Any, Optional, Iterator
 
 import httpx
@@ -19,7 +20,13 @@ class HTTPXResponse(HTTPResponse):
         return h
 
     def json(self) -> Any:
-        return json.loads(self._r.read().decode("utf-8"))
+        try:
+            decoded = self._r.read().decode("utf-8")
+            return json.loads(decoded)
+        except (JSONDecodeError, UnicodeDecodeError) as e:
+            raise ClientError(
+                f"Unable to decode response from endpoint {self._r.request.url}. Check that your "
+                f"endpoint is valid.") from e
 
     def status_code(self) -> int:
         return self._r.status_code

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,3 +1,7 @@
+import pytest
+
+from fauna.errors import ClientError
+
 from fauna import fql
 from fauna.client import Client
 
@@ -15,3 +19,11 @@ def test_client_txn_ts_are_independent(client, a_collection):
     assert client.get_last_txn_ts() is not None
     assert c.get_last_txn_ts() is not None
     assert client.get_last_txn_ts() != c.get_last_txn_ts()
+
+
+def test_handle_invalid_json_response():
+    err_msg = "Unable to decode response from endpoint https://dashboard.fauna.com/query/1. Check that your endpoint " \
+              "is valid."
+    with pytest.raises(ClientError, match=err_msg):
+        c = Client(endpoint="https://dashboard.fauna.com/")
+        c.query(fql("'foolery'"))


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-3679

## Problem

We were emitting a JSON error when we receive invalid JSON instead of a Client error.

## Solution

Try/Except

## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

New integ test.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

