### PR TITLE
Pipeline updated Publish Docs

### DIFF
--- a/concourse/scripts/publish_docs.sh
+++ b/concourse/scripts/publish_docs.sh
@@ -1,56 +1,41 @@
 #!/bin/sh
-
 set -eou pipefail
 
-cd ./fauna-python-repository
+apk add --no-progress --no-cache sed git
+
+cd fauna-python-repository
 
 pip install -r requirements.txt
+pip install pdoc3
 
 PACKAGE_VERSION=$(python setup.py --version)
 
-pip install .
-pip install requests
-pip install pdoc3
-pdoc fauna --html -o docs
+echo "Current docs version: ${PACKAGE_VERSION}"
 
+python -m pdoc ./fauna --html -o docs
+
+# use a new directory to add GTM to docs
 cd ../
 mkdir docs
 cp -R ./fauna-python-repository/docs/fauna/* ./docs/
 
-echo "Current docs version: $PACKAGE_VERSION"
-
-apk add --no-progress --no-cache sed
-
-echo "================================="
-echo "Adding google manager tag to head"
-echo "================================="
-
 HEAD_GTM=$(cat ./fauna-python-repository/concourse/scripts/head_gtm.dat)
 sed -i.bak "0,/<\/title>/{s/<\/title>/<\/title>${HEAD_GTM}/}" ./docs/index.html
-
-echo "================================="
-echo "Adding google manager tag to body"
-echo "================================="
 
 BODY_GTM=$(cat ./fauna-python-repository/concourse/scripts/body_gtm.dat)
 sed -i.bak "0,/<body>/{s/<body>/<body>${BODY_GTM}/}" ./docs/index.html
 
 rm ./docs/index.html.bak
 
-apk add --no-progress --no-cache git
-git clone fauna-python-repository-docs fauna-python-repository-updated-docs
-
 cd fauna-python-repository-updated-docs
 
-mkdir -p "$PACKAGE_VERSION"
-cd "$PACKAGE_VERSION"
-mkdir -p api
-cd ..
-cp -R ../docs/* ./"$PACKAGE_VERSION"/api/
+# copy modified docs into repo
+mkdir -p "${PACKAGE_VERSION}/api/"
+cp -R ../docs/* "./${PACKAGE_VERSION}/api/"
 
 git config --global user.email "nobody@fauna.com"
 git config --global user.name "Fauna, Inc"
 
-git add -A
+git add --all
 # only commit if we have new files
-git diff --exit-code || git commit -m "Update docs to version: $PACKAGE_VERSION"
+git diff --exit-code || git commit -m "Update docs to version: ${PACKAGE_VERSION}"


### PR DESCRIPTION
Ticket(s): BT-3693

## Problem

Python docs are not being published to the GH pages branch

## Solution

Updated the shell script that publishes docs

## Result

Version docs will be published to the `gh-pages` branch

## Testing

Created a local sandbox w/Docker


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

