### PR TITLE
Remove outdated query_check_codes

### DIFF
--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -350,7 +350,7 @@ class Client:
             ]
 
         if status_code == 400:
-            query_check_codes = [ "invalid_query" ]
+            query_check_codes = ["invalid_query"]
             if code in query_check_codes:
                 raise QueryCheckError(
                     status_code,

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -350,10 +350,7 @@ class Client:
             ]
 
         if status_code == 400:
-            query_check_codes = [
-                "invalid_function_definition", "invalid_identifier",
-                "invalid_query", "invalid_syntax", "invalid_type"
-            ]
+            query_check_codes = [ "invalid_query" ]
             if code in query_check_codes:
                 raise QueryCheckError(
                     status_code,


### PR DESCRIPTION
Ticket(s): BT-###, FE-###,...

I noticed there were a number of query_check_codes which were outdated/no longer used. The only one now which is a query check error is "invalid_query".

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

