### PR TITLE
Strict version requirements for deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-iso8601
-future
-httpx[http2]
+iso8601==1.1.0
+future==0.18.3
+httpx[http2]==0.23.*

--- a/setup.py
+++ b/setup.py
@@ -13,15 +13,17 @@ with open(path.join(local_dir, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 requires = [
-    "iso8601",
-    "future",
-    "httpx[http2]",
+    "iso8601==1.1.0",
+    "future==0.18.3",
+    "httpx[http2]==0.23.*",
 ]
 
 extras_require = {
-    "lint": ["yapf"],
-    "test":
-    ["pytest", "pytest-env", "pytest-cov", "pytest-httpx", "pytest-subtests"]
+    "lint": ["yapf==0.32.0"],
+    "test": [
+        "pytest==7.3.0", "pytest-env==0.8.1", "pytest-cov==4.0.0",
+        "pytest-httpx==0.21.3", "pytest-subtests==0.10.0"
+    ]
 }
 
 setup(


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem

The integ tests in a container were taking forever to setup because of loose dependency requirements.

## Solution

Peg deps to specific versions.

## Result

Container spins up much faster

## Testing

make docker-test


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

