### PR TITLE
Run tests with -v flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ install:
 test: unit-test integration-test coverage
 
 unit-test:
-	python -m coverage run -m pytest tests/unit
+	python -m coverage run -m pytest -v tests/unit
 
 integration-test:
-	python -m coverage run -m pytest tests/integration
+	python -m coverage run -m pytest -v tests/integration
 
 coverage:
 	python -m coverage report -m

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -22,6 +22,6 @@ until curl -m 1 --output /dev/null --silent --head --fail "${FAUNA_ENDPOINT}/pin
   sleep 5
 done
 
-python -m coverage run -m pytest tests/unit
-python -m coverage run -m pytest tests/integration
+python -m coverage run -m pytest -v tests/unit
+python -m coverage run -m pytest -v tests/integration
 python -m coverage report -m


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-###, FE-###,...

## Problem

Some diffs are truncated when they fail during testing.

## Solution

Add -v flag to pytest

## Result

Clearer test results

## Testing

make docker-test


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

