### PR TITLE
Use coverage not codecov

### DIFF
--- a/concourse/scripts/build.sh
+++ b/concourse/scripts/build.sh
@@ -5,5 +5,5 @@ set -eou pipefail
 cd ./fauna-python-repository
 
 pip install -r requirements.txt
-pip install codecov
+pip install coverage
 coverage run setup.py bdist_wheel --universal

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -5,7 +5,7 @@ set -eou pipefail
 apk add --update make curl
 
 pip install . ".[test]"
-pip install codecov
+pip install coverage
 
 attempt_counter=0
 max_attempts=100


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem

I suspect that the pypi object store migration revealed that we're using an unusual or deprecated package? Anyway, codecov is no longer found, and the documentation says we shoudl be using coverage.

## Solution

Update codecov to coverage

## Result

It works again.

## Testing

make docker-test


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

