### PR TITLE
Abort, InvalidRequest, and top-level info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,8 +136,8 @@ Stats are returned on query responses and ServiceErrors.
     except AuthenticationError as e:
         print(e)
     except ServiceError as e:
-        if e.query_info is not None:
-            emit_stats(e.query_info.stats)
+        if e.stats is not None:
+            emit_stats(e.stats)
         # more error handling...
 
 

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Stats are returned on query responses and ServiceErrors.
     from fauna import fql
     from fauna.client import Client
     from fauna.encoding import QuerySuccess, QueryStats
-    from fauna.errors import AuthenticationError, ServiceError
+    from fauna.errors import ServiceError
 
     client = Client()
 
@@ -133,8 +133,6 @@ Stats are returned on query responses and ServiceErrors.
         q = fql('Collection.create({ name: "Dogs" })')
         qs: QuerySuccess = client.query(q)
         emit_stats(qs.stats)
-    except AuthenticationError as e:
-        print(e)
     except ServiceError as e:
         if e.stats is not None:
             emit_stats(e.stats)

--- a/fauna/errors/__init__.py
+++ b/fauna/errors/__init__.py
@@ -2,4 +2,5 @@ from .errors import FaunaException
 from .errors import ClientError, FaunaError, NetworkError
 from .errors import ProtocolError, ServiceError
 from .errors import AuthenticationError, AuthorizationError, QueryCheckError, QueryRuntimeError, \
-    QueryTimeoutError, ServiceInternalError, ServiceTimeoutError, ThrottlingError
+    QueryTimeoutError, ServiceInternalError, ServiceTimeoutError, ThrottlingError, \
+    InvalidRequestError, AbortError

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -2,7 +2,7 @@ import pytest
 
 from fauna import fql
 from fauna.client import Client, QueryOptions
-from fauna.errors import QueryCheckError, QueryRuntimeError
+from fauna.errors import QueryCheckError, QueryRuntimeError, AbortError
 from fauna.encoding import ConstraintFailure
 
 
@@ -47,8 +47,7 @@ def test_query_with_constraint_failure(client):
     assert e.value.status_code == 400
     assert e.value.code == "constraint_failure"
     assert e.value.message == "Failed to create document in collection Function."
-    qi = e.value.query_info
-    assert qi is not None and len(qi.summary) > 0
+    assert len(e.value.summary) > 0
 
 
 def test_bad_request(client):
@@ -57,9 +56,22 @@ def test_bad_request(client):
 
     assert e.value.code == "invalid_query"
     assert len(e.value.message) > 0
-    assert e.value.query_info is not None
-    assert e.value.query_info.stats.query_time_ms > 0
-    assert len(e.value.query_info.summary) > 0
+    assert len(e.value.summary) > 0
+
+    stats = e.value.stats
+    assert stats is not None
+    assert stats.query_time_ms > 0
+
+
+def test_abort(client):
+    with pytest.raises(AbortError) as e:
+        client.query(fql("abort({'foo': 123})"))
+
+    ae: AbortError = e.value
+    assert ae.abort == {"foo": 123}
+    assert ae.code == "abort"
+    assert ae.status_code == 400
+    assert ae.stats.compute_ops == 1
 
 
 @pytest.mark.skip(reason="not currently supported by core")

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -343,7 +343,7 @@ def test_error_protocol_error_missing_error_key(subtests,
     with httpx.Client() as mockClient:
         http_client = HTTPXClient(mockClient)
         c = Client(http_client=http_client)
-        err = "400: Unexpected response\nResponse is in an unknown format: \n{'data': 'jumped'}"
+        err = "400: Response is in an unknown format: \n{'data': 'jumped'}"
         with pytest.raises(ProtocolError, match=err):
             c.query(fql("the quick brown fox"))
 
@@ -364,7 +364,7 @@ def test_error_protocol_error_missing_error_code(subtests,
     with httpx.Client() as mockClient:
         http_client = HTTPXClient(mockClient)
         c = Client(http_client=http_client)
-        err = "400: Unexpected response\nResponse is in an unknown format: \n{'error': {'message': 'boo'}}"
+        err = "400: Response is in an unknown format: \n{'error': {'message': 'boo'}}"
         with pytest.raises(ProtocolError, match=err):
             c.query(fql("the quick brown fox"))
 
@@ -385,7 +385,7 @@ def test_error_protocol_error_missing_error_message(subtests,
     with httpx.Client() as mockClient:
         http_client = HTTPXClient(mockClient)
         c = Client(http_client=http_client)
-        err = "400: Unexpected response\nResponse is in an unknown format: \n{'error': {'code': 'boo'}}"
+        err = "400: Response is in an unknown format: \n{'error': {'code': 'boo'}}"
         with pytest.raises(ProtocolError, match=err):
             c.query(fql("the quick brown fox"))
 
@@ -403,7 +403,7 @@ def test_error_protocol_data_missing(subtests, httpx_mock: HTTPXMock):
     with httpx.Client() as mockClient:
         http_client = HTTPXClient(mockClient)
         c = Client(http_client=http_client)
-        err = "200: Unexpected response\nResponse is in an unknown format: \n{}"
+        err = "200: Response is in an unknown format: \n{}"
         with pytest.raises(ProtocolError, match=err):
             c.query(fql("the quick brown fox"))
 


### PR DESCRIPTION
BT-3714

<!-- Reminder: Keep READMEs up to date -->

## Problem

We need AbortError and InvalidRequestError, and nested query info feels wrong.

## Solution

* For abort handling, we need to decode abort. Instead of decoding just data, decode the entire body after the protocol check. This allows the success/failure cases to access decoded body without worrying about it.
* Move QueryInfo props to the top-level of ServiceError with multiple inheritance
* Remove FaunaError inheritance from ProtocolError. It's not really a FaunaError, or at least it probably isn't.


## Testing

Unit and integ tests pass


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

