### PR TITLE
Use a diff key for testtools

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -24,7 +24,7 @@ resources:
     source:
       uri: git@github.com:fauna/fauna-python.git
       branch: gh-pages
-      private_key: ((github_repo_key))
+      private_key: ((github-ssh-key))
 
   - name: testtools-repo
     type: git
@@ -32,7 +32,7 @@ resources:
     source:
       uri: git@github.com:fauna/testtools.git
       branch: main
-      private_key: ((github_repo_key))
+      private_key: ((github-ssh-key))
 
   - name: testtools-image
     type: registry-image


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem

We need to use a different key to get at testttools


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

