### PR TITLE
Improve client encoding error message

### DIFF
--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -207,7 +207,7 @@ class Client:
         try:
             encoded_query: Mapping[str, Any] = FaunaEncoder.encode(fql)
         except Exception as e:
-            raise ClientError("Failed to evaluate Query") from e
+            raise ClientError("Failed to encode Query") from e
 
         return self._query(
             "/query/1",

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -1,8 +1,11 @@
+import json
+from types import SimpleNamespace
+
 import pytest
 
 from fauna import fql, Page
 from fauna.client import Client, QueryOptions
-from fauna.errors import QueryCheckError, QueryRuntimeError, AbortError
+from fauna.errors import QueryCheckError, QueryRuntimeError, AbortError, ClientError
 from fauna.encoding import ConstraintFailure
 
 
@@ -109,3 +112,11 @@ if (true) {
   41
 }"""))
     assert res.static_type == "42 | 41"
+
+
+def test_fails_on_encoding_error():
+    body = '{"orderProducts": {}}'
+    test = json.loads(body, object_hook=lambda d: SimpleNamespace(**d))
+    client = Client()
+    with pytest.raises(ClientError, match="Failed to encode Query"):
+        client.query(fql("${prods}", prods=test.orderProducts))


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem

Evaluate implies that we've sent the query to Fauna, but we've just failed to encode.

## Solution

Use "encode" instead of "evaluate" in error message.
## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

Describe the manual and automated tests you completed to verify the change is working as expected.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

