### PR TITLE
Add support for null doc

### DIFF
--- a/fauna/__init__.py
+++ b/fauna/__init__.py
@@ -5,6 +5,6 @@ __author__ = "Fauna, Inc"
 __license__ = "MPL 2.0"
 __copyright__ = "2023 Fauna, Inc"
 
-from fauna.query import fql, Document, DocumentReference, NamedDocument, NamedDocumentReference, Module, Page
+from fauna.query import fql, Document, DocumentReference, NamedDocument, NamedDocumentReference, NullDocument, Module, Page
 
 global_http_client = None

--- a/fauna/encoding/encoder.py
+++ b/fauna/encoding/encoder.py
@@ -1,7 +1,7 @@
 from datetime import datetime, date
 from typing import Any, Optional, Set
 
-from fauna.query.models import DocumentReference, Module, Document, NamedDocument, NamedDocumentReference
+from fauna.query.models import DocumentReference, Module, Document, NamedDocument, NamedDocumentReference, NullDocument
 from fauna.query.query_builder import Query, Fragment, LiteralFragment, ValueFragment
 
 _RESERVED_TAGS = [
@@ -194,6 +194,8 @@ class FaunaEncoder:
         elif isinstance(o, NamedDocument):
             return FaunaEncoder.from_named_doc_ref(
                 NamedDocumentReference(o.coll, o.name))
+        elif isinstance(o, NullDocument):
+            return FaunaEncoder.encode(o.ref)
         elif isinstance(o, (list, tuple)):
             return FaunaEncoder._encode_list(o, _markers)
         elif isinstance(o, dict):

--- a/fauna/query/__init__.py
+++ b/fauna/query/__init__.py
@@ -1,2 +1,2 @@
 from .query_builder import fql, Query
-from .models import Document, DocumentReference, NamedDocument, NamedDocumentReference, Module, Page
+from .models import Document, DocumentReference, NamedDocument, NamedDocumentReference, NullDocument, Module, Page

--- a/fauna/query/models.py
+++ b/fauna/query/models.py
@@ -100,8 +100,7 @@ class DocumentReference(BaseReference):
         super().__init__(coll)
 
         if not isinstance(id, str):
-            raise TypeError(
-                f"'ref_id' should be of type str, but was {type(id)}")
+            raise TypeError(f"'id' should be of type str, but was {type(id)}")
         self._id = id
 
     def __hash__(self):
@@ -144,6 +143,37 @@ class NamedDocumentReference(BaseReference):
 
     def __repr__(self):
         return f"{self.__class__.__name__}(name={repr(self._name)},coll={repr(self._collection)})"
+
+
+class NullDocument:
+
+    @property
+    def cause(self) -> Optional[str]:
+        return self._cause
+
+    @property
+    def ref(self) -> Union[DocumentReference, NamedDocumentReference]:
+        return self._ref
+
+    def __init__(
+        self,
+        ref: Union[DocumentReference, NamedDocumentReference],
+        cause: Optional[str] = None,
+    ):
+        self._cause = cause
+        self._ref = ref
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(ref={repr(self.ref)},cause={repr(self._cause)})"
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return False
+
+        return self.ref == other.ref and self.cause == other.cause
+
+    def __ne__(self, other):
+        return not self == other
 
 
 class BaseDocument(Mapping):


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem

We introduced a Null Document for scenarios when the document may not exist. This needs explicit support in drivers.

## Solution

* Add NullDocument class that accepts a DocumentReference and NamedDocumentReference. I opted for this to avoid a NullDocumentReference and NullNamedDocumentReference.
* Decode @ref where exists == false into NullDocument
* Encodes into a @ref that excludes the exists and cause properties

## Testing

Added unit and integ tests


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

