### PR TITLE
Encode arrays as queries instead of values

### DIFF
--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -1,5 +1,6 @@
 import json
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -125,3 +126,17 @@ def test_null_doc(client, a_collection):
     r = client.query(fql("${coll}.byId('123')", coll=a_collection))
     assert isinstance(r.data, NullDocument)
     assert r.data.cause == "not found"
+
+
+def test_list_of_queries_is_injection_safe(client):
+    arr: Any = [fql("${n}", n=n) for n in range(2)]
+
+    r = client.query(fql("${arr}", arr=[*arr, "1 + 1"]))
+    assert r.data == [0, 1, "1 + 1"]
+
+
+def test_list_of_lists(client):
+    inner = [fql("1"), fql("2")]
+    outer = [inner]
+    r = client.query(fql("${arr}", arr=outer))
+    assert r.data == [[1, 2]]

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -848,3 +848,17 @@ def test_encode_list_of_list():
             }, ']']
         }, ']']
     }
+
+
+def test_query_inside_object_raises_type_error():
+    obj = {"q": fql("1")}
+    with pytest.raises(TypeError,
+                       match="Queries aren't supported inside objects"):
+        FaunaEncoder.encode(obj)
+
+
+def test_query_inside_array_embedded_in_object_raises_type_error():
+    obj = {"q": [fql("1")]}
+    with pytest.raises(TypeError,
+                       match="Queries aren't supported inside objects"):
+        FaunaEncoder.encode(obj)


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->


## Problem

We encode lists as { "value": ... }, which means they can't hold any FQL Queries.

## Solution

Encode lists as an FQL query instead of a value, except when they're already embedded inside a dictionary.

## Result

This enables patterns like the following:

```
queries = [fql("${n}", n=n) for n in range(10)]
result = client.query(fql("${queries}", queries=queries))

# result.data = [1,2,3,4,5,6,7,8,9,10]
```

## Testing

Unit and integration tests.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

