### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from fauna import __version__ as pkg_version
 # Load the README file for use in the long description
 local_dir = path.abspath(path.dirname(__file__))
 with open(path.join(local_dir, "README.rst"), encoding="utf-8") as f:
-    long_description = f.read()
+  long_description = f.read()
 
 requires = [
     "iso8601==1.1.0",
@@ -52,9 +52,14 @@ setup(
     ],
     keywords="faunadb fauna",
     packages=[
-        "fauna", "fauna.client", "fauna.encoding", "fauna.errors",
-        "fauna.http", "fauna.query"
+        "fauna",
+        "fauna.client",
+        "fauna.encoding",
+        "fauna.errors",
+        "fauna.http",
+        "fauna.query",
     ],
+    python_requires='>=3.9, <4',
     install_requires=requires,
     extras_require=extras_require,
 )


### PR DESCRIPTION
Ticket(s): #118 

## Problem

> Currently, one is able to install this package in an environment using Python 3.8 or older as the package setup script does not specify the python range it supports. This python version metadata should be added to the setup script.

## Solution

Specify `python_requires`

## Result

Improved UX

## Testing

`python setup.py check`

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

