### PR TITLE
Implement Client.paginate

### DIFF
--- a/fauna/query/iterator.py
+++ b/fauna/query/iterator.py
@@ -1,0 +1,56 @@
+from typing import Iterator, Optional
+
+from fauna.client.client import Client, QueryOptions
+from fauna.query import Query, fql, Page
+
+
+class QueryIterator:
+    """A class to provider an iterator on top of Fauna queries."""
+
+    def __init__(
+        self, 
+        client: Client, 
+        fql: Query, 
+        opts: Optional[QueryOptions] = None
+    ):
+        """Initializes the QueryIterator
+
+        :param fql: A string, but will eventually be a query expression.
+        :param opts: (Optional) Query Options
+
+        :raises TypeError: Invalid param types
+        """
+        if not isinstance(client, Client):
+            err_msg = f"'client' must be a Client but was a {type(client)}. You can build a " \
+                        f"Client by calling fauna.client.Client()"
+            raise TypeError(err_msg)
+
+        if not isinstance(fql, Query):
+            err_msg = f"'fql' must be a Query but was a {type(fql)}. You can build a " \
+                       f"Query by calling fauna.fql()"
+            raise TypeError(err_msg)
+
+        self.client = client
+        self.fql = fql
+        self.opts = opts
+        self.cursor = None
+        
+    def __iter__(self) -> Iterator:
+        return self.iter()
+    
+    def iter(self) -> Iterator:
+        initialResponse = self.client.query(self.fql, self.opts)
+        
+        if isinstance(initialResponse.data, Page):
+            self.cursor = initialResponse.data.after
+            yield initialResponse.data.data
+
+            while self.cursor is not None:
+                nextResponse = self.client.query(
+                    fql("Set.paginate(${after})", after=self.cursor),
+                    self.opts)
+                self.cursor = nextResponse.data.after
+                yield nextResponse.data.data
+                
+        else:
+            yield initialResponse.data

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,6 @@
 import random
 import string
+from typing import Tuple
 
 import pytest
 
@@ -29,3 +30,18 @@ def a_collection(client, suffix) -> Module:
     q = create_collection(col_name)
     client.query(q)
     return Module(col_name)
+
+@pytest.fixture
+def pagination_collections(client, suffix) -> Tuple[Module, Module]:
+    
+    small_name = f"IterTestSmall_{suffix}"
+    client.query(create_collection(small_name))
+    for i in range(0, 10):
+        client.query(fql("${mod}.create({ value: ${i} })", mod=Module(small_name), i=i))
+
+    big_name = f"IterTestBig_{suffix}"
+    client.query(create_collection(big_name))
+    for i in range(0, 20):
+        client.query(fql("${mod}.create({ value: ${i} })", mod=Module(big_name), i=i))
+
+    return (Module(small_name), Module(big_name))

--- a/tests/integration/test_paginate.py
+++ b/tests/integration/test_paginate.py
@@ -1,0 +1,24 @@
+from fauna import fql
+
+def test_single_page_with_small_collection(client, pagination_collections):
+    small_coll, _ = pagination_collections
+
+    query_iterator = client.paginate(fql("${mod}.all()", mod=small_coll))
+    
+    page_count = 0
+    for page in query_iterator:
+      page_count += 1
+      assert len(page) == 10
+      
+    assert page_count == 1
+
+def test_multiple_pages_with_big_collection(client, pagination_collections):
+    _, big_coll = pagination_collections
+
+    query_iterator = client.paginate(fql("${mod}.all()", mod=big_coll))
+    
+    page_count = 0
+    for _ in query_iterator:
+      page_count += 1
+      
+    assert page_count == 2


### PR DESCRIPTION
Ticket(s): BT-3725

Pushing up for an early review.

## Problem
We want to provide a convenient way to paginate through large datasets that require multiple requests.

## Solution
Add a Client.paginate method that takes a Query and returns an iterator to fetch multiple pages of data.

## Result
Added a new QueryIterator class to store the FQL and make multiple requests if the result is a page with an after cursor.

If the FQL query results in something other than a page, the iterator returns one element with that result.

WIP:
- [ ] add a flatten method to QueryIterator to provide an iterator over the page's items, rather than a full Page.
- [ ] add more testing

## Testing
Added integration tests.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

