### PR TITLE
Fix query timeout

### DIFF
--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -257,7 +257,7 @@ class Client:
         headers[_Header.Authorization] = self._auth.bearer()
 
         if self._query_timeout_ms is not None:
-            headers[Header.TimeoutMs] = str(self._query_timeout_ms)
+            headers[Header.QueryTimeoutMs] = str(self._query_timeout_ms)
 
         headers.update(self._last_txn_ts.request_header)
 
@@ -275,7 +275,7 @@ class Client:
                 headers[Header.Traceparent] = opts.traceparent
             if opts.query_timeout is not None:
                 timeout_ms = f"{int(opts.query_timeout.total_seconds() * 1000)}"
-                headers[Header.TimeoutMs] = timeout_ms
+                headers[Header.QueryTimeoutMs] = timeout_ms
             if opts.query_tags is not None:
                 query_tags.update(opts.query_tags)
             if opts.typecheck is not None:

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -274,7 +274,7 @@ class Client:
             if opts.traceparent is not None:
                 headers[Header.Traceparent] = opts.traceparent
             if opts.query_timeout is not None:
-                timeout_ms = f"{opts.query_timeout.total_seconds() * 1000}"
+                timeout_ms = f"{int(opts.query_timeout.total_seconds() * 1000)}"
                 headers[Header.TimeoutMs] = timeout_ms
             if opts.query_tags is not None:
                 query_tags.update(opts.query_tags)

--- a/fauna/client/headers.py
+++ b/fauna/client/headers.py
@@ -11,7 +11,7 @@ class Header:
     LastTxnTs = "X-Last-Txn-Ts"
     Linearized = "X-Linearized"
     MaxContentionRetries = "X-Max-Contention-Retries"
-    TimeoutMs = "X-Query-Timeout-Ms"
+    QueryTimeoutMs = "X-Query-Timeout-Ms"
     Typecheck = "X-Typecheck"
     Tags = "X-Query-Tags"
     Traceparent = "Traceparent"

--- a/fauna/client/headers.py
+++ b/fauna/client/headers.py
@@ -11,7 +11,7 @@ class Header:
     LastTxnTs = "X-Last-Txn-Ts"
     Linearized = "X-Linearized"
     MaxContentionRetries = "X-Max-Contention-Retries"
-    TimeoutMs = "X-Timeout-Ms"
+    TimeoutMs = "X-Query-Timeout-Ms"
     Typecheck = "X-Typecheck"
     Tags = "X-Query-Tags"
     Traceparent = "Traceparent"

--- a/tests/integration/test_paginate.py
+++ b/tests/integration/test_paginate.py
@@ -101,7 +101,6 @@ def test_can_get_pages_using_a_loop_with_next(client, pagination_collections):
     assert page_count == 2
 
 
-@pytest.mark.skip(reason="query_timeout not properly handled yet")
 def test_respects_query_options(client, pagination_collections):
     _, big_coll = pagination_collections
 
@@ -109,9 +108,5 @@ def test_respects_query_options(client, pagination_collections):
         fql("${mod}.create({ name: 'Wah' })", mod=big_coll),
         QueryOptions(query_timeout=timedelta(milliseconds=1)))
 
-    try:
+    with pytest.raises(QueryTimeoutError):
         next(query_iterator.iter())
-    except QueryTimeoutError:
-        assert True
-
-    assert False

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -128,12 +128,7 @@ def test_null_doc(client, a_collection):
     assert r.data.cause == "not found"
 
 
-@pytest.mark.skip(reason="query_timeout not properly handled yet")
 def test_query_timeout(client, a_collection):
-    try:
+    with pytest.raises(QueryTimeoutError):
         client.query(fql("${coll}.byId('123')", coll=a_collection),
                      QueryOptions(query_timeout=timedelta(milliseconds=1)))
-    except QueryTimeoutError:
-        assert True
-
-    assert False

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -135,7 +135,7 @@ def test_query_options_set(httpx_mock: HTTPXMock):
         Validate each of the associated Headers are set on the request
         """
         assert request.headers[Header.Linearized] == str(linearized).lower()
-        assert request.headers[Header.TimeoutMs] == f"{query_timeout_ms}"
+        assert request.headers[Header.QueryTimeoutMs] == f"{query_timeout_ms}"
         assert request.headers[Header.Traceparent] == traceparent
         assert request.headers[Header.Typecheck] == str(typecheck).lower()
         assert request.headers[Header.MaxContentionRetries] == f"{max_contention_retries}"  # yapf: disable

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -121,7 +121,7 @@ def test_query_options_set(httpx_mock: HTTPXMock):
 
     typecheck = True
     linearized = True
-    query_timeout_ms = 5000.0
+    query_timeout_ms = 5000
     traceparent = "happy-little-fox"
     max_contention_retries = 5
     tags = {


### PR DESCRIPTION
Ticket(s): BT-3938

## Problem

- we set `x-timeout-ms` instead of `x-query-timeout-ms`
- we send the header as a float, e.g. `5000.0` instead of `5000`

## Solution
Update the header and header encoding.

## Result
Query timeouts are enforced correctly.

## Testing
Added a test that`QueryTimeoutError`s get raised when queries run beyond the specified `query_timeout` configuration.
Added a test for `Client.paginate` that uses query timeouts to demonstrate that options are getting passed down to requests.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

