### PR TITLE
Encode Query timeout header correctly

### DIFF
--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -22,7 +22,7 @@ jobs:
           cache: pip
 
       - name: Install yapf
-        run: pip install yapf
+        run: pip install yapf==0.40.1
 
       - name: Check Format
         run: |

--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,7 @@ If you want to run fauna, then run integration tests separately:
 
 .. code-block:: bash
 
-    $ make docker-fauna
+    $ make run-fauna
     $ source venv/bin/activate
     $ make install
     $ make integration-test

--- a/fauna/__init__.py
+++ b/fauna/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "Fauna"
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __api_version__ = "10"
 __author__ = "Fauna, Inc"
 __license__ = "MPL 2.0"

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -86,7 +86,7 @@ class Client:
             self._query_tags.update(query_tags)
 
         if query_timeout is not None:
-            self._query_timeout_ms = query_timeout.total_seconds() * 1000
+            self._query_timeout_ms = int(query_timeout.total_seconds() * 1000)
         else:
             self._query_timeout_ms = None
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requires = [
 ]
 
 extras_require = {
-    "lint": ["yapf==0.32.0"],
+    "lint": ["yapf==0.40.1"],
     "test": [
         "pytest==7.3.0", "pytest-env==0.8.1", "pytest-cov==4.0.0",
         "pytest-httpx==0.21.3", "pytest-subtests==0.10.0"

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,4 +1,6 @@
+from datetime import timedelta
 import pytest
+from fauna.client.client import QueryOptions
 
 from fauna.errors import ClientError
 
@@ -27,3 +29,11 @@ def test_handle_invalid_json_response():
     with pytest.raises(ClientError, match=err_msg):
         c = Client(endpoint="https://dashboard.fauna.com/")
         c.query(fql("'foolery'"))
+
+
+def test_fauna_accepts_query_timeout_header():
+    c1 = Client(query_timeout=timedelta(seconds=5))
+    c1.query(fql('"hello"'))
+
+    c2 = Client()
+    c2.query(fql('"hello"'), QueryOptions(query_timeout=timedelta(seconds=5)))


### PR DESCRIPTION
Ticket(s): BT-3997

fixes #126 

## Problem
When the `query_timeout` option is provided to the client configuration, the `X-Query-Timeout-Ms` header gets encoded as a decimal. e.g. "5000.0" instead of "5000". Fauna returns a 400 error when this happens.

## Solution
Make sure that the header is encoded as an integer.

We did this for when the query timeout is configured in QueryOptions (see #124), but we didn't cover the client config path.

Add test coverage for configuring and actually sending a request.

## Result
Clients can be configured with query_timeout and Fauna will respect it.

## Testing
Added a test to actually send requests with a client configured with query_timeout. One request with client config and one request with no client config but with QueryOptions.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

