### PR TITLE
Add Schema Version

### DIFF
--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -316,6 +316,7 @@ class Client:
       query_tags = QueryTags.decode(
           dec["query_tags"]) if "query_tags" in dec else None
       txn_ts = dec["txn_ts"] if "txn_ts" in dec else None
+      schema_version = dec["schema_version"] if "schema_version" in dec else None
       traceparent = headers.get("traceparent", None)
       static_type = dec["static_type"] if "static_type" in dec else None
 
@@ -327,6 +328,7 @@ class Client:
           summary=summary,
           traceparent=traceparent,
           txn_ts=txn_ts,
+          schema_version=schema_version,
       )
 
   def _check_protocol(self, response_json: Any, status_code):

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -363,6 +363,7 @@ class Client:
         body["query_tags"]) if "query_tags" in body else None
     stats = QueryStats(body["stats"]) if "stats" in body else None
     txn_ts = body["txn_ts"] if "txn_ts" in body else None
+    schema_version = body["schema_version"] if "schema_version" in body else None
     summary = body["summary"] if "summary" in body else None
 
     constraint_failures: Optional[List[ConstraintFailure]] = None
@@ -386,6 +387,7 @@ class Client:
             query_tags=query_tags,
             stats=stats,
             txn_ts=txn_ts,
+            schema_version=schema_version,
         )
       elif code == "invalid_request":
         raise InvalidRequestError(
@@ -397,6 +399,7 @@ class Client:
             query_tags=query_tags,
             stats=stats,
             txn_ts=txn_ts,
+            schema_version=schema_version,
         )
       elif code == "abort":
         abort = err["abort"] if "abort" in err else None
@@ -410,6 +413,7 @@ class Client:
             query_tags=query_tags,
             stats=stats,
             txn_ts=txn_ts,
+            schema_version=schema_version,
         )
 
       else:
@@ -422,6 +426,7 @@ class Client:
             query_tags=query_tags,
             stats=stats,
             txn_ts=txn_ts,
+            schema_version=schema_version,
         )
     elif status_code == 401:
       raise AuthenticationError(
@@ -433,6 +438,7 @@ class Client:
           query_tags=query_tags,
           stats=stats,
           txn_ts=txn_ts,
+          schema_version=schema_version,
       )
     elif status_code == 403:
       raise AuthorizationError(
@@ -444,6 +450,7 @@ class Client:
           query_tags=query_tags,
           stats=stats,
           txn_ts=txn_ts,
+          schema_version=schema_version,
       )
     elif status_code == 429:
       raise ThrottlingError(
@@ -455,6 +462,7 @@ class Client:
           query_tags=query_tags,
           stats=stats,
           txn_ts=txn_ts,
+          schema_version=schema_version,
       )
     elif status_code == 440:
       raise QueryTimeoutError(
@@ -466,6 +474,7 @@ class Client:
           query_tags=query_tags,
           stats=stats,
           txn_ts=txn_ts,
+          schema_version=schema_version,
       )
     elif status_code == 500:
       raise ServiceInternalError(
@@ -477,6 +486,7 @@ class Client:
           query_tags=query_tags,
           stats=stats,
           txn_ts=txn_ts,
+          schema_version=schema_version,
       )
     elif status_code == 503:
       raise ServiceTimeoutError(
@@ -488,6 +498,7 @@ class Client:
           query_tags=query_tags,
           stats=stats,
           txn_ts=txn_ts,
+          schema_version=schema_version,
       )
     else:
       raise ServiceError(
@@ -499,6 +510,7 @@ class Client:
           query_tags=query_tags,
           stats=stats,
           txn_ts=txn_ts,
+          schema_version=schema_version,
       )
 
   def _set_endpoint(self, endpoint):

--- a/fauna/encoding/wire_protocol.py
+++ b/fauna/encoding/wire_protocol.py
@@ -95,7 +95,13 @@ class QueryInfo:
 
   @property
   def txn_ts(self) -> int:
+    """The last transaction timestamp of the query. A Unix epoch in microseconds."""
     return self._txn_ts
+
+  @property
+  def schema_version(self) -> int:
+    """The schema version that was used for the query execution."""
+    return self._schema_version
 
   def __init__(
       self,
@@ -103,18 +109,21 @@ class QueryInfo:
       stats: Optional[QueryStats] = None,
       summary: Optional[str] = None,
       txn_ts: Optional[int] = None,
+      schema_version: Optional[int] = None,
   ):
     self._query_tags = query_tags or {}
     self._stats = stats or QueryStats({})
     self._summary = summary or ""
     self._txn_ts = txn_ts or 0
+    self._schema_version = schema_version or 0
 
   def __repr__(self):
     return f"{self.__class__.__name__}(" \
            f"query_tags={repr(self.query_tags)}," \
            f"stats={repr(self.stats)}," \
            f"summary={repr(self.summary)}," \
-           f"txn_ts={repr(self.txn_ts)})"
+           f"txn_ts={repr(self.txn_ts)}," \
+           f"schema_version={repr(self.schema_version)})"
 
 
 class QuerySuccess(QueryInfo):
@@ -144,10 +153,16 @@ class QuerySuccess(QueryInfo):
       summary: Optional[str],
       traceparent: Optional[str],
       txn_ts: Optional[int],
+      schema_version: Optional[int],
   ):
 
     super().__init__(
-        query_tags=query_tags, stats=stats, summary=summary, txn_ts=txn_ts)
+        query_tags=query_tags,
+        stats=stats,
+        summary=summary,
+        txn_ts=txn_ts,
+        schema_version=schema_version,
+    )
 
     self._traceparent = traceparent
     self._static_type = static_type
@@ -161,6 +176,7 @@ class QuerySuccess(QueryInfo):
            f"summary={repr(self.summary)}," \
            f"traceparent={repr(self.traceparent)}," \
            f"txn_ts={repr(self.txn_ts)}," \
+           f"schema_version={repr(self.schema_version)}," \
            f"data={repr(self.data)})"
 
 

--- a/fauna/errors/errors.py
+++ b/fauna/errors/errors.py
@@ -95,6 +95,7 @@ class ServiceError(FaunaError, QueryInfo):
       query_tags: Optional[Mapping[str, str]] = None,
       stats: Optional[QueryStats] = None,
       txn_ts: Optional[int] = None,
+      schema_version: Optional[int] = None,
   ):
     QueryInfo.__init__(
         self,
@@ -102,6 +103,7 @@ class ServiceError(FaunaError, QueryInfo):
         stats=stats,
         summary=summary,
         txn_ts=txn_ts,
+        schema_version=schema_version,
     )
 
     FaunaError.__init__(

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -18,6 +18,7 @@ def test_query_smoke_test(subtests, client):
     assert res.stats.compute_ops > 0
     assert res.traceparent != ""
     assert res.summary == ""
+    assert res.schema_version > 0
 
   with subtests.test(msg="with debug"):
     res = client.query(fql('dbg("Hello, World")'))

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -4,8 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
-import fauna
-from fauna import fql, Page, NullDocument
+from fauna import fql, Page, NullDocument, Module
 from fauna.client import Client, QueryOptions
 from fauna.errors import QueryCheckError, QueryRuntimeError, AbortError, ClientError, QueryTimeoutError
 from fauna.encoding import ConstraintFailure
@@ -147,5 +146,5 @@ def test_query_schema_version(client):
   r = client.query(fql("Collection.create({ name: ${name} })", name=coll_name))
   expected_schema_version = r.txn_ts
 
-  r = client.query(fql("${mod}.all()", mod=fauna.Module(coll_name)))
+  r = client.query(fql("${mod}.all()", mod=Module(coll_name)))
   assert expected_schema_version == r.schema_version

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import fauna
 from fauna import fql, Page, NullDocument
 from fauna.client import Client, QueryOptions
 from fauna.errors import QueryCheckError, QueryRuntimeError, AbortError, ClientError, QueryTimeoutError
@@ -137,3 +138,14 @@ def test_query_timeout(client, a_collection):
     client.query(
         fql("${coll}.byId('123')", coll=a_collection),
         QueryOptions(query_timeout=timedelta(milliseconds=1)))
+
+
+def test_query_schema_version(client):
+  coll_name = "schemaVersionTestColl"
+
+  _ = client.query(fql("Collection.byName(${coll})?.delete()", coll=coll_name))
+  r = client.query(fql("Collection.create({ name: ${name} })", name=coll_name))
+  expected_schema_version = r.txn_ts
+
+  r = client.query(fql("${mod}.all()", mod=fauna.Module(coll_name)))
+  assert expected_schema_version == r.schema_version

--- a/tests/unit/test_wire_protocol.py
+++ b/tests/unit/test_wire_protocol.py
@@ -10,6 +10,7 @@ def test_query_success_repr():
       summary="human readable",
       traceparent=None,
       txn_ts=123,
+      schema_version=123,
   )
   stats = "{'compute_ops': 1, 'read_ops': 0, 'write_ops': 0, " \
           "'query_time_ms': 0, 'storage_bytes_read': 0, 'storage_bytes_write': 0, " \
@@ -20,10 +21,12 @@ def test_query_success_repr():
                      "summary='human readable'," \
                      "traceparent=None," \
                      "txn_ts=123," \
+                     "schema_version=123," \
                      "data={'foo': 'bar'})"
 
   evaluated: QuerySuccess = eval(repr(qs))
   assert evaluated.txn_ts == qs.txn_ts
+  assert evaluated.schema_version == qs.schema_version
   assert evaluated.traceparent == qs.traceparent
   assert evaluated.query_tags == qs.query_tags
   assert evaluated.data == qs.data
@@ -38,6 +41,7 @@ def test_query_info_repr():
       stats=QueryStats({'compute_ops': 1}),
       summary="human readable",
       txn_ts=123,
+      schema_version=123,
   )
   stats = "{'compute_ops': 1, 'read_ops': 0, 'write_ops': 0, " \
           "'query_time_ms': 0, 'storage_bytes_read': 0, 'storage_bytes_write': 0, " \
@@ -45,13 +49,15 @@ def test_query_info_repr():
   assert repr(qi) == "QueryInfo(query_tags={'tag': 'value'}," \
                      f"stats=QueryStats(stats={stats})," \
                      "summary='human readable'," \
-                     "txn_ts=123)"
+                     "txn_ts=123," \
+                     "schema_version=123)"
 
   evaluated: QueryInfo = eval(repr(qi))
   assert evaluated.txn_ts == qi.txn_ts
   assert evaluated.query_tags == qi.query_tags
   assert evaluated.summary == qi.summary
   assert evaluated.stats == qi.stats
+  assert evaluated.schema_version == qi.schema_version
 
 
 def test_query_stats_repr():


### PR DESCRIPTION
Ticket(s): BT-4059

## Problem

Driver needs to be updated to support Schema Version which is now part of the query response. 

## Solution

Add Schema Version

## Result

The schema version used by the query. This can be used by clients displaying schema to determine when they should refresh their schema. If the schema version that a client has stored differs from the one returned by the query, schema should be refreshed.

## Testing

Additional test included


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

