### PR TITLE
Updated timeouts

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -20,7 +20,7 @@ def test_client_defaults(monkeypatch):
 
   assert client._endpoint == "https://db.fauna.com"
   assert client._auth.secret == ""
-  assert client._query_timeout_ms is None
+  assert client._query_timeout_ms is not None
   assert client._session == fauna.global_http_client
 
 
@@ -110,7 +110,7 @@ def test_get_set_transaction_time():
 
 
 def test_get_query_timeout():
-  c = Client()
+  c = Client(query_timeout=None)
   assert c.get_query_timeout() is None
 
   c = Client(query_timeout=timedelta(minutes=1))


### PR DESCRIPTION
Ticket(s): BT-3922

## Problem

1) Consumers are unable to specify their own timeout settings
2) We should be setting a default Query Timeout & Client Buffer Timeout

## Solution

- Timeouts can optionally be set when initializing a new client
- Set defaults for Query and Client Buffer Timeouts

## Result

- Improved defaults
- Consumers can override settings as desired

## Testing

Basic local testing

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

