### PR TITLE
Pydoc publishing

### DIFF
--- a/concourse/scripts/publish_docs.sh
+++ b/concourse/scripts/publish_docs.sh
@@ -17,7 +17,7 @@ python -m pdoc ./fauna --output-directory docs
 # use a new directory to add GTM to docs
 cd ../
 mkdir docs
-cp -R ./fauna-python-repository/docs/fauna/* ./docs/
+cp -R ./fauna-python-repository/docs/* ./docs/
 
 HEAD_GTM=$(cat ./fauna-python-repository/concourse/scripts/head_gtm.dat)
 sed -i.bak "0,/<\/title>/{s/<\/title>/<\/title>${HEAD_GTM}/}" ./docs/index.html

--- a/concourse/scripts/publish_docs.sh
+++ b/concourse/scripts/publish_docs.sh
@@ -20,10 +20,10 @@ mkdir docs
 cp -R ./fauna-python-repository/docs/* ./docs/
 
 HEAD_GTM=$(cat ./fauna-python-repository/concourse/scripts/head_gtm.dat)
-sed -i.bak "0,/<\/title>/{s/<\/title>/<\/title>${HEAD_GTM}/}" ./docs/index.html
+sed -i.bak "0,/<\/title>/{s/<\/title>/<\/title>${HEAD_GTM}/}" ./docs/fauna.html
 
 BODY_GTM=$(cat ./fauna-python-repository/concourse/scripts/body_gtm.dat)
-sed -i.bak "0,/<body>/{s/<body>/<body>${BODY_GTM}/}" ./docs/index.html
+sed -i.bak "0,/<body>/{s/<body>/<body>${BODY_GTM}/}" ./docs/fauna.html
 
 rm ./docs/index.html.bak
 


### PR DESCRIPTION
Ticket(s): BT-4066

## Problem

```
sed: can't read ./docs/index.html: No such file or directory
```

pdoc has a different output structure

## Solution

Copy the contents `docs/` 

## Result

Files are published as expected

## Testing

https://fauna.github.io/fauna-python/0.8.0/fauna/client/client.html -- built in a local docker image and published manually since the pipeline failed

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

