### PR TITLE
Support Contended Transaction Errors

### DIFF
--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Iterator, Mapping, Optional, List
 import fauna
 from fauna.errors import AuthenticationError, ClientError, ProtocolError, ServiceError, AuthorizationError, \
     ServiceInternalError, ServiceTimeoutError, ThrottlingError, QueryTimeoutError, QueryRuntimeError, \
-    QueryCheckError, AbortError, InvalidRequestError
+    QueryCheckError, ContendedTransactionError, AbortError, InvalidRequestError
 from fauna.client.headers import _DriverEnvironment, _Header, _Auth, Header
 from fauna.http.http_client import HTTPClient
 from fauna.query import Query, Page, fql
@@ -464,6 +464,18 @@ class Client:
       )
     elif status_code == 403:
       raise AuthorizationError(
+          status_code=status_code,
+          code=code,
+          message=message,
+          summary=summary,
+          constraint_failures=constraint_failures,
+          query_tags=query_tags,
+          stats=stats,
+          txn_ts=txn_ts,
+          schema_version=schema_version,
+      )
+    elif status_code == 409:
+      raise ContendedTransactionError(
           status_code=status_code,
           code=code,
           message=message,

--- a/fauna/errors/__init__.py
+++ b/fauna/errors/__init__.py
@@ -2,5 +2,5 @@ from .errors import FaunaException
 from .errors import ClientError, FaunaError, NetworkError
 from .errors import ProtocolError, ServiceError
 from .errors import AuthenticationError, AuthorizationError, QueryCheckError, QueryRuntimeError, \
-    QueryTimeoutError, ServiceInternalError, ServiceTimeoutError, ThrottlingError, \
+    QueryTimeoutError, ServiceInternalError, ServiceTimeoutError, ThrottlingError, ContendedTransactionError, \
     InvalidRequestError, AbortError

--- a/fauna/errors/errors.py
+++ b/fauna/errors/errors.py
@@ -136,6 +136,11 @@ class QueryCheckError(ServiceError):
   pass
 
 
+class ContendedTransactionError(ServiceError):
+  """Transaction is aborted due to concurrent modification."""
+  pass
+
+
 class QueryRuntimeError(ServiceError):
   """An error response that is the result of the query failing during execution.
     QueryRuntimeError's occur when a bug in your query causes an invalid execution


### PR DESCRIPTION
Ticket(s): BT-3657

## Problem

Not currently mapping Contended Transaction Errors 

## Solution

Add `ContendedTransactionError` type

## Result

Proper type for the error

## Testing

None - I didn't add a test since it would require that we simulate concurrent operations within the test which I figured could be flakey.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

