### PR TITLE
provide a way to close the http client

### DIFF
--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -172,6 +172,11 @@ class Client:
 
       self._session = fauna.global_http_client
 
+  def close(self):
+    self._session.close()
+    if self._session == fauna.global_http_client:
+      fauna.global_http_client = None
+
   def set_last_txn_ts(self, txn_ts: int):
     """
         Set the last timestamp seen by this client.

--- a/fauna/http/http_client.py
+++ b/fauna/http/http_client.py
@@ -65,3 +65,7 @@ class HTTPClient(abc.ABC):
       data: Mapping[str, Any],
   ) -> HTTPResponse:
     pass
+
+  @abc.abstractmethod
+  def close(self):
+    pass

--- a/fauna/http/httpx_client.py
+++ b/fauna/http/httpx_client.py
@@ -85,3 +85,6 @@ class HTTPXClient(HTTPClient):
       data: Mapping[str, Any],
   ) -> Iterator[HTTPResponse]:
     raise NotImplementedError()
+
+  def close(self):
+    self._c.close()


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-3723

## Problem

Customers need a way to gracefully close connections to Fauna.

## Solution

Provide a close method on the Fauna client and underlying HTTP clients. If the Fauna Client is using the global http client, the global client is closed and set to None to prevent use of a closed client.

## Result

Clients can be closed.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

