### PR TITLE
retry on transport errors

### DIFF
--- a/fauna/http/httpx_client.py
+++ b/fauna/http/httpx_client.py
@@ -69,14 +69,26 @@ class HTTPXClient(HTTPClient):
       raise ClientError("Invalid URL Format") from e
 
     try:
+      return HTTPXResponse(self._send_with_retry(3, request))
+    except (httpx.HTTPError, httpx.InvalidURL) as e:
+      raise NetworkError("Exception re-raised from HTTP request") from e
+
+  def _send_with_retry(
+      self,
+      retryCount: int,
+      request: httpx.Request,
+  ) -> httpx.Response:
+    try:
       response = self._c.send(
           request,
           stream=False,
       )
-    except (httpx.HTTPError, httpx.InvalidURL) as e:
-      raise NetworkError("Exception re-raised from HTTP request") from e
-
-    return HTTPXResponse(response)
+      return response
+    except httpx.TransportError as e:
+      if retryCount == 0:
+        raise e
+      else:
+        return self._send_with_retry(retryCount - 1, request)
 
   def stream(
       self,


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-3908

## Problem

There are environments where a client may see a transport error that is safe to retry.

## Solution

Handle the retry internally up to a limit (3).

## Result

Transient transport errors are automatically handled in the client.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

