### PR TITLE
Add retry config for 429/502 errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,12 @@ When building queries, adapt your classes into dicts or lists prior to using the
 Client Configuration
 --------------------
 
+Retry Policy
+------------
+A retry policy can be set on the client. By default, this is configured with `max_attempts` of 3, inclusive of the initial call, and `max_backoff` of 20 seconds. The retry strategy implemented is a simple exponential backoff and will retry only on a ThrottlingError.
+
+To disable retries, pass a RetryPolicy with max_attempts set to 1.
+
 Timeouts
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ Client Configuration
 
 Retry Policy
 ------------
-A retry policy can be set on the client. By default, this is configured with `max_attempts` of 3, inclusive of the initial call, and `max_backoff` of 20 seconds. The retry strategy implemented is a simple exponential backoff and will retry only on a ThrottlingError.
+A retry policy can be set on the client. By default, this is configured with `max_attempts` of 3, inclusive of the initial call, and `max_backoff` of 20 seconds. The retry strategy implemented is a simple exponential backoff and will retry on 429s and 502s.
 
 To disable retries, pass a RetryPolicy with max_attempts set to 1.
 

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -220,7 +220,7 @@ class Client:
         returns a Page, the iterator will fetch additional Pages until the
         after token is null. Each call for a page will be retried with exponential
         backoff up to the max_attempts set in the client's retry policy in the
-        event of a ThrottlingError.
+        event of a 429 or 502.
 
         :param fql: A Query
         :param opts: (Optional) Query Options
@@ -249,7 +249,7 @@ class Client:
     """
         Run a query on Fauna. A query will be retried with exponential backoff
         up to the max_attempts set in the client's retry policy in the event
-        of a ThrottlingError.
+        of a 429 or 502.
 
         :param fql: A Query
         :param opts: (Optional) Query Options

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -6,7 +6,7 @@ import fauna
 from fauna.client.retryable import RetryPolicy, Retryable
 from fauna.errors import AuthenticationError, ClientError, ProtocolError, ServiceError, AuthorizationError, \
     ServiceInternalError, ServiceTimeoutError, ThrottlingError, QueryTimeoutError, QueryRuntimeError, \
-    QueryCheckError, ContendedTransactionError, AbortError, InvalidRequestError
+    QueryCheckError, ContendedTransactionError, AbortError, InvalidRequestError, RetryableNetworkError
 from fauna.client.headers import _DriverEnvironment, _Header, _Auth, Header
 from fauna.http.http_client import HTTPClient
 from fauna.query import Query, Page, fql
@@ -279,7 +279,10 @@ class Client:
         "/query/1",
         fql=encoded_query,
         opts=opts)
-    return retryable.run()
+
+    r = retryable.run()
+    r.response.stats.attempts = r.attempts
+    return r.response
 
   def _query(
       self,
@@ -334,9 +337,12 @@ class Client:
         headers=headers,
         data=data,
     ) as response:
+      status_code = response.status_code()
+      if status_code == 502:
+        raise RetryableNetworkError(502, response.text())
+
       response_json = response.json()
       headers = response.headers()
-      status_code = response.status_code()
 
       self._check_protocol(response_json, status_code)
 

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -86,7 +86,7 @@ class Client:
         :param http_connect_timeout: Set HTTP Connect timeout, default is :py:data:`DefaultHttpConnectTimeout`.
         :param http_pool_timeout: Set HTTP Pool timeout, default is :py:data:`DefaultHttpPoolTimeout`.
         :param http_idle_timeout: Set HTTP Idle timeout, default is :py:data:`DefaultIdleConnectionTimeout`.
-        :param retry_policy: A retry policy
+        :param retry_policy: A retry policy. The default policy sets max_attempts to 3 and max_backoff to 20.
         """
 
     self._set_endpoint(endpoint)
@@ -218,7 +218,9 @@ class Client:
     """
         Run a query on Fauna and returning an iterator of results. If the query
         returns a Page, the iterator will fetch additional Pages until the
-        after token is null.
+        after token is null. Each call for a page will be retried with exponential
+        backoff up to the max_attempts set in the client's retry policy in the
+        event of a ThrottlingError.
 
         :param fql: A Query
         :param opts: (Optional) Query Options
@@ -245,7 +247,9 @@ class Client:
       opts: Optional[QueryOptions] = None,
   ) -> QuerySuccess:
     """
-        Run a query on Fauna.
+        Run a query on Fauna. A query will be retried with exponential backoff
+        up to the max_attempts set in the client's retry policy in the event
+        of a ThrottlingError.
 
         :param fql: A Query
         :param opts: (Optional) Query Options

--- a/fauna/client/retryable.py
+++ b/fauna/client/retryable.py
@@ -1,0 +1,80 @@
+import abc
+from dataclasses import dataclass
+from random import random
+from time import sleep
+from typing import Callable, Any, Optional, Union
+
+from fauna.encoding import QuerySuccess
+from fauna.errors import ThrottlingError, ServiceError
+
+
+@dataclass
+class RetryPolicy:
+  max_attempts: int = 3
+  """An int. The maximum number of attempts."""
+
+  max_backoff: int = 20
+  """An int. The maximum backoff in seconds."""
+
+
+class RetryStrategy:
+
+  @abc.abstractmethod
+  def wait(self) -> float:
+    pass
+
+
+class ExponentialBackoffStrategy(RetryStrategy):
+
+  def __init__(self, max_backoff: int):
+    self._max_backoff = float(max_backoff)
+    self._i = 0.0
+
+  def wait(self) -> float:
+    """Returns the number of seconds to wait for the next call."""
+    backoff = random() * (2.0**self._i)
+    self._i += 1.0
+    return min(backoff, self._max_backoff)
+
+
+class Retryable:
+  """
+    Retryable is a wrapper class that acts on a Callable that returns a QuerySuccess.
+    """
+  _strategy: RetryStrategy
+  _error: Optional[Exception]
+
+  def __init__(self, policy: RetryPolicy,
+               func: Union[Callable[[Any], QuerySuccess],
+                           Callable[[], QuerySuccess]], *args, **kwargs):
+    self._max_attempts = policy.max_attempts
+    self._strategy = ExponentialBackoffStrategy(policy.max_backoff)
+    self._func = func
+    self._args = args
+    self._kwargs = kwargs
+    self._error = None
+
+  def run(self) -> QuerySuccess:
+    """Runs the wrapped function. Retries up to max_attempts if the function throws a ThrottlingError. It propagates
+        the thrown exception if max_attempts is reached or if a non-ThrottlingError is thrown.
+
+        Assigns attempts to QuerySuccess.stats.attempts and ServiceError.stats.attempts
+        """
+    error: Optional[Exception] = None
+    attempt = 0
+    for i in range(self._max_attempts):
+      sleep_time = 0.0 if attempt == 0 else self._strategy.wait()
+      sleep(sleep_time)
+      try:
+        attempt += 1
+        qs = self._func(*self._args, **self._kwargs)
+        qs.stats.attempts = attempt
+        return qs
+      except ThrottlingError as e:
+        e.stats.attempts = attempt
+        error = e
+      except ServiceError as e:
+        e.stats.attempts = attempt
+        raise e
+
+    raise error

--- a/fauna/client/retryable.py
+++ b/fauna/client/retryable.py
@@ -5,7 +5,7 @@ from time import sleep
 from typing import Callable, Optional
 
 from fauna.encoding import QuerySuccess
-from fauna.errors import RetryableFaunaException
+from fauna.errors import RetryableFaunaException, ClientError
 
 
 @dataclass
@@ -70,10 +70,9 @@ class Retryable:
 
         Returns the number of attempts and the response
         """
-
+    err: Optional[RetryableFaunaException] = None
     attempt = 0
-    for i in range(self._max_attempts):
-
+    while True:
       sleep_time = 0.0 if attempt == 0 else self._strategy.wait()
       sleep(sleep_time)
 
@@ -82,5 +81,5 @@ class Retryable:
         qs = self._func(*self._args, **self._kwargs)
         return RetryableResponse(attempt, qs)
       except RetryableFaunaException as e:
-        if i == self._max_attempts:
+        if attempt >= self._max_attempts:
           raise e

--- a/fauna/encoding/wire_protocol.py
+++ b/fauna/encoding/wire_protocol.py
@@ -40,6 +40,15 @@ class QueryStats:
     """The number of times the transaction was retried due to write contention."""
     return self._contention_retries
 
+  @property
+  def attempts(self) -> int:
+    """The number of attempts made by the client to run the query."""
+    return self._attempts
+
+  @attempts.setter
+  def attempts(self, value):
+    self._attempts = value
+
   def __init__(self, stats: Mapping[str, Any]):
     self._compute_ops = stats.get("compute_ops", 0)
     self._read_ops = stats.get("read_ops", 0)
@@ -48,6 +57,7 @@ class QueryStats:
     self._storage_bytes_read = stats.get("storage_bytes_read", 0)
     self._storage_bytes_write = stats.get("storage_bytes_write", 0)
     self._contention_retries = stats.get("contention_retries", 0)
+    self._attempts = 0
 
   def __repr__(self):
     stats = {
@@ -58,6 +68,7 @@ class QueryStats:
         "storage_bytes_read": self._storage_bytes_read,
         "storage_bytes_write": self._storage_bytes_write,
         "contention_retries": self._contention_retries,
+        "attempts": self._attempts,
     }
 
     return f"{self.__class__.__name__}(stats={repr(stats)})"
@@ -70,7 +81,8 @@ class QueryStats:
         and self.query_time_ms == other.query_time_ms \
         and self.storage_bytes_read == other.storage_bytes_read \
         and self.storage_bytes_write == other.storage_bytes_write \
-        and self.contention_retries == other.contention_retries
+        and self.contention_retries == other.contention_retries \
+        and self.attempts == other.attempts
 
   def __ne__(self, other):
     return not self.__eq__(other)

--- a/fauna/errors/__init__.py
+++ b/fauna/errors/__init__.py
@@ -3,4 +3,4 @@ from .errors import ClientError, FaunaError, NetworkError
 from .errors import ProtocolError, ServiceError
 from .errors import AuthenticationError, AuthorizationError, QueryCheckError, QueryRuntimeError, \
     QueryTimeoutError, ServiceInternalError, ServiceTimeoutError, ThrottlingError, ContendedTransactionError, \
-    InvalidRequestError, AbortError
+    InvalidRequestError, AbortError, RetryableFaunaException, RetryableNetworkError

--- a/fauna/errors/errors.py
+++ b/fauna/errors/errors.py
@@ -8,6 +8,10 @@ class FaunaException(Exception):
   pass
 
 
+class RetryableFaunaException(FaunaException):
+  pass
+
+
 class ClientError(FaunaException):
   """An error representing a failure internal to the client, itself.
     This indicates Fauna was never called - the client failed internally
@@ -19,6 +23,24 @@ class NetworkError(FaunaException):
   """An error representing a failure due to the network.
     This indicates Fauna was never reached."""
   pass
+
+
+class RetryableNetworkError(RetryableFaunaException):
+
+  @property
+  def status_code(self) -> int:
+    return self._status_code
+
+  @property
+  def message(self) -> str:
+    return self._message
+
+  def __init__(self, status_code: int, message: str):
+    self._status_code = status_code
+    self._message = message
+
+  def __str__(self):
+    return f"{self.status_code}: {self.message}"
 
 
 class ProtocolError(FaunaException):
@@ -160,7 +182,7 @@ class AuthorizationError(ServiceError):
   pass
 
 
-class ThrottlingError(ServiceError):
+class ThrottlingError(ServiceError, RetryableFaunaException):
   """ThrottlingError indicates some capacity limit was exceeded
     and thus the request could not be served."""
   pass

--- a/fauna/http/http_client.py
+++ b/fauna/http/http_client.py
@@ -27,6 +27,10 @@ class HTTPResponse(abc.ABC):
     pass
 
   @abc.abstractmethod
+  def text(self) -> Any:
+    pass
+
+  @abc.abstractmethod
   def read(self) -> bytes:
     pass
 
@@ -36,6 +40,10 @@ class HTTPResponse(abc.ABC):
 
   @abc.abstractmethod
   def close(self):
+    pass
+
+  @abc.abstractmethod
+  def attempts(self) -> int:
     pass
 
   def __enter__(self):

--- a/fauna/http/http_client.py
+++ b/fauna/http/http_client.py
@@ -27,7 +27,7 @@ class HTTPResponse(abc.ABC):
     pass
 
   @abc.abstractmethod
-  def text(self) -> Any:
+  def text(self) -> str:
     pass
 
   @abc.abstractmethod

--- a/fauna/http/http_client.py
+++ b/fauna/http/http_client.py
@@ -42,10 +42,6 @@ class HTTPResponse(abc.ABC):
   def close(self):
     pass
 
-  @abc.abstractmethod
-  def attempts(self) -> int:
-    pass
-
   def __enter__(self):
     return self
 

--- a/fauna/http/httpx_client.py
+++ b/fauna/http/httpx_client.py
@@ -28,6 +28,9 @@ class HTTPXResponse(HTTPResponse):
           f"Unable to decode response from endpoint {self._r.request.url}. Check that your endpoint is valid."
       ) from e
 
+  def text(self) -> str:
+    return str(self.read(), encoding='utf-8')
+
   def status_code(self) -> int:
     return self._r.status_code
 

--- a/tests/unit/test_retryable.py
+++ b/tests/unit/test_retryable.py
@@ -37,7 +37,7 @@ def test_retryable_throws_on_non_throttling_error():
   with pytest.raises(ServiceError) as e:
     retryable.run()
 
-  assert e.value.attempts == 1
+  assert e.value.stats.attempts == 1
 
 
 def test_retryable_retries_on_throttling_error():

--- a/tests/unit/test_retryable.py
+++ b/tests/unit/test_retryable.py
@@ -1,0 +1,69 @@
+import pytest
+from typing import List, Optional
+
+from fauna.client.retryable import Retryable, RetryPolicy, ExponentialBackoffStrategy
+from fauna.encoding import QuerySuccess, QueryStats
+from fauna.errors import ThrottlingError, ServiceError
+
+
+class Tester:
+
+  def __init__(self, errors: List[Optional[Exception]]):
+    self.errors = errors
+    self.calls = 0
+
+  def f(self, _ = ""):
+    v = self.errors[self.calls]
+    self.calls += 1
+
+    if v is not None:
+      raise v
+
+    return QuerySuccess({}, None, None, QueryStats({}), None, None, None, None)
+
+
+def test_retryable_no_retry():
+  tester = Tester([None])
+  policy = RetryPolicy()
+  retryable = Retryable(policy, tester.f)
+  res = retryable.run()
+  assert res.stats.attempts == 1
+
+
+def test_retryable_throws_on_non_throttling_error():
+  tester = Tester([ServiceError(400, "oops", "not"), None])
+  policy = RetryPolicy()
+  retryable = Retryable(policy, tester.f)
+  with pytest.raises(ServiceError) as e:
+    retryable.run()
+
+  assert e.value.attempts == 1
+
+
+def test_retryable_retries_on_throttling_error():
+  tester = Tester([ThrottlingError(429, "oops", "throttled"), None])
+  policy = RetryPolicy()
+  retryable = Retryable(policy, tester.f)
+  res = retryable.run()
+  assert res.stats.attempts == 2
+
+
+def test_retryable_throws_when_exceeding_max_attempts():
+  err = ThrottlingError(429, "oops", "throttled")
+  tester = Tester([err, err, err, err])
+  policy = RetryPolicy()
+  retryable = Retryable(policy, tester.f)
+  with pytest.raises(ThrottlingError) as e:
+    retryable.run()
+  assert e.value.stats.attempts == 3
+
+
+def test_strategy_backs_off():
+  strat = ExponentialBackoffStrategy(max_backoff=20)
+  b1 = strat.wait()
+  b2 = strat.wait()
+  b3 = strat.wait()
+
+  assert 0.0 <= b1 <= 1.0
+  assert 0.0 <= b2 <= 2.0
+  assert 0.0 <= b3 <= 4.0

--- a/tests/unit/test_retryable.py
+++ b/tests/unit/test_retryable.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from fauna.client.retryable import Retryable, RetryPolicy, ExponentialBackoffStrategy
 from fauna.encoding import QuerySuccess, QueryStats
-from fauna.errors import ThrottlingError, ServiceError
+from fauna.errors import ThrottlingError, ServiceError, RetryableNetworkError
 
 
 class Tester:
@@ -26,26 +26,32 @@ def test_retryable_no_retry():
   tester = Tester([None])
   policy = RetryPolicy()
   retryable = Retryable(policy, tester.f)
-  res = retryable.run()
-  assert res.stats.attempts == 1
+  r = retryable.run()
+  assert r.attempts == 1
 
 
 def test_retryable_throws_on_non_throttling_error():
   tester = Tester([ServiceError(400, "oops", "not"), None])
   policy = RetryPolicy()
   retryable = Retryable(policy, tester.f)
-  with pytest.raises(ServiceError) as e:
+  with pytest.raises(ServiceError):
     retryable.run()
-
-  assert e.value.stats.attempts == 1
 
 
 def test_retryable_retries_on_throttling_error():
   tester = Tester([ThrottlingError(429, "oops", "throttled"), None])
   policy = RetryPolicy()
   retryable = Retryable(policy, tester.f)
-  res = retryable.run()
-  assert res.stats.attempts == 2
+  r = retryable.run()
+  assert r.attempts == 2
+
+
+def test_retryable_retries_on_502():
+  tester = Tester([RetryableNetworkError(502, "bad gateway"), None])
+  policy = RetryPolicy()
+  retryable = Retryable(policy, tester.f)
+  r = retryable.run()
+  assert r.attempts == 2
 
 
 def test_retryable_throws_when_exceeding_max_attempts():
@@ -53,9 +59,8 @@ def test_retryable_throws_when_exceeding_max_attempts():
   tester = Tester([err, err, err, err])
   policy = RetryPolicy()
   retryable = Retryable(policy, tester.f)
-  with pytest.raises(ThrottlingError) as e:
+  with pytest.raises(ThrottlingError):
     retryable.run()
-  assert e.value.stats.attempts == 3
 
 
 def test_strategy_backs_off():

--- a/tests/unit/test_retryable.py
+++ b/tests/unit/test_retryable.py
@@ -12,7 +12,7 @@ class Tester:
     self.errors = errors
     self.calls = 0
 
-  def f(self, _ = ""):
+  def f(self, _=""):
     v = self.errors[self.calls]
     self.calls += 1
 

--- a/tests/unit/test_wire_protocol.py
+++ b/tests/unit/test_wire_protocol.py
@@ -14,7 +14,7 @@ def test_query_success_repr():
   )
   stats = "{'compute_ops': 1, 'read_ops': 0, 'write_ops': 0, " \
           "'query_time_ms': 0, 'storage_bytes_read': 0, 'storage_bytes_write': 0, " \
-          "'contention_retries': 0}"
+          "'contention_retries': 0, 'attempts': 0}"
   assert repr(qs) == "QuerySuccess(query_tags={'tag': 'value'}," \
                      "static_type=None," \
                      f"stats=QueryStats(stats={stats})," \
@@ -45,7 +45,7 @@ def test_query_info_repr():
   )
   stats = "{'compute_ops': 1, 'read_ops': 0, 'write_ops': 0, " \
           "'query_time_ms': 0, 'storage_bytes_read': 0, 'storage_bytes_write': 0, " \
-          "'contention_retries': 0}"
+          "'contention_retries': 0, 'attempts': 0}"
   assert repr(qi) == "QueryInfo(query_tags={'tag': 'value'}," \
                      f"stats=QueryStats(stats={stats})," \
                      "summary='human readable'," \
@@ -68,12 +68,13 @@ def test_query_stats_repr():
       'query_time_ms': 4,
       'storage_bytes_read': 5,
       'storage_bytes_write': 6,
-      'contention_retries': 7
+      'contention_retries': 7,
+      'attempts': 0,
   })
 
   stats = "{'compute_ops': 1, 'read_ops': 2, 'write_ops': 3, " \
           "'query_time_ms': 4, 'storage_bytes_read': 5, 'storage_bytes_write': 6, " \
-          "'contention_retries': 7}"
+          "'contention_retries': 7, 'attempts': 0}"
 
   assert repr(qs) == f"QueryStats(stats={stats})"
 


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-3465

## Problem

ThrottlingError is very retryable, but we don't currently retry.

## Solution

* Implement a basic exponential backoff retry strategy for ThrottlingError.
* Expose RetryPolicy configuration at the client level
* Default the RetryPolicy to 3 max attempts and a maximum backoff of 20 seconds


## Testing

Added unit tests. Existing integ tests pass.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

