### PR TITLE
BT-4181: Add query limits integration test and add to pipeline

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -97,6 +97,13 @@ jobs:
                 FAUNA_SECRET: ((drivers-platform-tests/fauna-secret))
                 VERCEL_TOKEN: ((drivers-platform-tests/vercel-token))
 
+            - task: query-limits-tests
+              privileged: true
+              file: fauna-python-repository/concourse/tasks/query-limits-tests.yml
+              params:
+                QUERY_LIMITS_DB: limited
+                QUERY_LIMITS_COLL: limitCollection
+
 
   - name: release
     serial: true

--- a/concourse/tasks/query-limits-tests.yml
+++ b/concourse/tasks/query-limits-tests.yml
@@ -1,0 +1,32 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: shared-concourse-dind
+    aws_access_key_id: ((prod-images-aws-access-key-id))
+    aws_secret_access_key: ((prod-images-aws-secret-key))
+    aws_region: us-east-2
+
+params:
+  FAUNA_ENDPOINT: http://fauna-limits:8443
+  QUERY_LIMITS_DB:
+  QUERY_LIMITS_COLL:
+
+inputs:
+  - name: fauna-python-repository
+  - name: testtools-repo
+
+run:
+  path: entrypoint.sh
+  args:
+    - bash
+    - -ceu
+    - |
+      # setup Fauna container
+      docker-compose -f testtools-repo/fauna-driver-query-limits-tests/docker-compose.yml run setup
+      # run tests
+      docker-compose -f fauna-python-repository/tests/docker-compose-limits-tests.yml run query-limits-tests
+      # stop and remove containers
+      docker-compose -f fauna-python-repository/tests/docker-compose-limits-tests.yml down
+      docker-compose -f testtools-repo/fauna-driver-query-limits-tests/docker-compose.yml down

--- a/tests/docker-compose-limits-tests.yml
+++ b/tests/docker-compose-limits-tests.yml
@@ -1,0 +1,22 @@
+version: "3.5"
+
+networks:
+  limit-net:
+    external: true
+    name: limit-net
+
+services:
+  query-limits-tests:
+    environment:
+      FAUNA_ENDPOINT: ${FAUNA_ENDPOINT:-http://fauna-limits:8443}
+      QUERY_LIMITS_DB: ${QUERY_LIMITS_DB}
+      QUERY_LIMITS_COLL: ${QUERY_LIMITS_COLL}
+    image: python:3.12.0-alpine3.17
+    container_name: query-limits-tests
+    networks:
+      - limit-net
+    volumes:
+      - "../:/tmp/app"
+    working_dir: "/tmp/app"
+    command:
+      - tests/run-query-limits-tests.sh

--- a/tests/integration/test_client_with_query_limits.py
+++ b/tests/integration/test_client_with_query_limits.py
@@ -9,7 +9,7 @@ from fauna.encoding import QuerySuccess
 
 
 def query_collection(client: Client) -> QuerySuccess:
-  coll_name = os.environ.get("QUERY_LIMITS_COLL")
+  coll_name = os.environ.get("QUERY_LIMITS_COLL") or ""
   return client.query(fql("${coll}.all().paginate(50)", coll=fql(coll_name)))
 
 

--- a/tests/integration/test_client_with_query_limits.py
+++ b/tests/integration/test_client_with_query_limits.py
@@ -1,0 +1,41 @@
+from multiprocessing.pool import ThreadPool
+import os
+
+import pytest
+
+from fauna import fql
+from fauna.client import Client
+from fauna.encoding import QuerySuccess
+
+
+def query_collection(client: Client) -> QuerySuccess:
+  coll_name = os.environ.get("QUERY_LIMITS_COLL")
+  return client.query(fql("${coll}.all().paginate(50)", coll=fql(coll_name)))
+
+
+@pytest.mark.skipif("QUERY_LIMITS_DB" not in os.environ or "QUERY_LIMITS_COLL" not in os.environ,
+                    reason="QUERY_LIMITS_DB and QUERY_LIMITS_COLL must both be set to run this test")
+def test_client_retries_throttled_query():
+  db_name = os.environ.get("QUERY_LIMITS_DB")
+  rootClient = Client()
+  res = rootClient.query(fql("""
+if (Database.byName(${db}).exists()) {
+  Key.create({ role: "admin", database: ${db} }) { secret }
+} else {
+  abort("Database not found.")
+}""", db=db_name))
+  secret = res.data["secret"]
+  clients = [ Client(secret=secret) for _ in range(5) ]
+  throttled = False
+
+  with ThreadPool() as pool:
+    results = pool.map(query_collection, clients)
+
+    for result in results:
+      if result.stats.attempts > 1:
+        throttled = True
+
+  assert throttled == True
+
+  for cl in clients:
+    cl.close()

--- a/tests/run-query-limits-tests.sh
+++ b/tests/run-query-limits-tests.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# NOTE: this file is intended to be ran from within the Docker image
+set -eou pipefail
+
+apk add --update make
+
+pip install . ".[test]"
+pip install coverage
+
+python -m coverage run -m pytest -v tests/integration/test_client_with_query_limits.py
+python -m coverage report -m


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-4181

## Problem
We don't currently have integration test coverage of the query-limit and throttling behavior.

## Solution
Add a test case that runs against a specially-configured database with query limits and validate that the queries that are throttled succeed on the Client retry logic (`stats.attempts > 1`).

Dependent on the files merged in this PR: https://github.com/fauna/testtools/pull/86

## Result
New test case added and running in pipeline.

## Out of scope

## Testing
Ran the test locally using the multiple docker-compose files; will need to validate in the pipeline that the Concourse collateral is setup correctly, but I was mostly able to copy what works in the JS driver after some iterations there.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

