### PR TITLE
Initial work to support streams

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,24 +19,9 @@ jobs:
           - "3.11"
           - "3.10"
           - "3.9"
-        fauna-docker-service:
-          - name: "fauna/faunadb:latest"
-            host: "core"
-            port: "8443"
-          # if we had a nightly image, we could run the testsuite against it by uncommented this
-          # - name: "fauna/faunadb:nightly"
-          #   host: "localhost"
-          #   port: "8443"
 
     timeout-minutes: 5
     runs-on: ubuntu-latest
-
-    container:
-      image: python:${{ matrix.python-version}}
-
-    services:
-      core:
-        image: ${{ matrix.fauna-docker-service.name }}
 
     steps:
       - uses: actions/checkout@v3
@@ -44,23 +29,17 @@ jobs:
       - name: Show file descriptor limit
         run: ulimit -a
 
-      - name: "Install ci dependencies"
-        run: pip install . .[test] .[lint] --use-pep517
+      - name: Build docker
+        run: docker-compose -f docker/docker-compose.yml build --build-arg BASE_IMG=python:${{ matrix.python-version }} --no-cache
 
       - name: Run unit tests
-        run: pytest -v --cov=fauna --cov-context=test tests/unit
+        run: docker-compose -f docker/docker-compose.yml run --rm unit-test
 
       - name: Run integration tests
-        run: pytest -v --cov=fauna --cov-context=test tests/integration
-        # To get more insight into tests which are only flaky when run in github actions -- use commands like below
-        # run: env HTTPX_LOG_LEVEL=trace pytest --capture=no -v --cov=fauna --cov-context=test -k test_stream_max_open_streams
-        env:
-          FAUNA_ENDPOINT: "http://${{ matrix.fauna-docker-service.host }}:${{ matrix.fauna-docker-service.port }}"
-          FAUNA_ROOT_KEY: secret
-          USE_GITHUB_ACTION_OVERRIDES: 1
+        run: docker-compose -f docker/docker-compose.yml run --rm integration-test
 
       - name: Generate coverage html report with dynamic contexts
-        run: coverage html --show-contexts
+        run: docker-compose -f docker/docker-compose.yml run --rm coverage
 
       - uses: actions/upload-artifact@v3
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+ARG BASE_IMG=?
+
+FROM $BASE_IMG
+
+WORKDIR /fauna-python
+VOLUME /fauna-python
+
+COPY . /fauna-python/
+
+RUN cd /fauna-python && pip install . .[test] .[lint] --use-pep517

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3"
+
+services:
+  db:
+    image: fauna/faunadb:latest
+    ports:
+      - "8443:8443"
+    volumes:
+      - ../docker/feature-flags.json:/etc/feature-flag-periodic.d/feature-flags.json
+  test:
+    image: fauna-python-test:latest
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+  integration-test:
+    image: fauna-python-test:latest
+    volumes:
+      - ..:/fauna-python
+    command:
+      - /bin/bash
+      - -cx
+      - |
+        while ! curl -s --fail -m 1 http://db:8443/ping 2>&1; do sleep 3; done
+        pytest -v --cov=fauna --cov-context=test tests/integration
+    environment:
+      - FAUNA_ENDPOINT=http://db:8443
+    depends_on:
+      - db
+  unit-test:
+    image: fauna-python-test:latest
+    volumes:
+      - ..:/fauna-python
+    command: pytest -v --cov=fauna --cov-context=test tests/unit
+  coverage:
+    image: fauna-python-test:latest
+    volumes:
+      - ..:/fauna-python
+    command: coverage html --show-contexts

--- a/docker/feature-flags.json
+++ b/docker/feature-flags.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "properties": [
+    {
+      "property_name": "cluster_name",
+      "property_value": "fauna",
+      "flags": {
+        "fql2_schema": true,
+        "fqlx_typecheck_default": true,
+        "persisted_fields": true,
+        "changes_by_collection_index": true,
+        "fql2_streams": true
+      }
+    },
+    {
+      "property_name": "account_id",
+      "property_value": 0,
+      "flags": {
+        "fql2_schema": true,
+        "fqlx_typecheck_default": true,
+        "persisted_fields": true,
+        "changes_by_collection_index": true,
+        "fql2_streams": true
+      }
+    }
+  ]
+}

--- a/fauna/client/__init__.py
+++ b/fauna/client/__init__.py
@@ -1,3 +1,3 @@
-from .client import Client, QueryOptions
+from .client import Client, QueryOptions, StreamOptions
 from .endpoints import Endpoints
 from .headers import Header

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -618,6 +618,7 @@ class StreamIterator:
     self.ctx = self.client._stream(self.fql, None)
     self.stream = None
     self.last_ts = 0
+    self.error = False
 
   def __enter__(self):
     self.stream = self.ctx.__enter__()
@@ -632,9 +633,10 @@ class StreamIterator:
 
   def __next__(self):
     try:
-      if self.stream is not None:
+      if not self.error and self.stream is not None:
         event: Any = FaunaDecoder.decode(next(self.stream))
         self.last_ts = event["ts"]
+        self.error = event["type"] == "error"
         return event
 
       raise StopIteration

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -666,9 +666,9 @@ class StreamIterator:
       if self.stream is not None:
         event: Any = FaunaDecoder.decode(next(self.stream))
         self.last_ts = event["ts"]
+
         if event["type"] == "error":
-          # todo: parse error
-          raise StreamError
+          raise StreamError(event["message"], event["code"], event.get("stats"))
 
         if event["type"] == "start":
           return self._next_element()

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, Mapping, Optional, List
+from typing import Any, Dict, Iterator, Mapping, Optional, List, Union
 from contextlib import contextmanager
 
 import fauna
@@ -378,7 +378,7 @@ class Client:
           schema_version=schema_version,
       )
 
-  def stream(self, fql: StreamToken | Query) -> "StreamIterator":
+  def stream(self, fql: Union[StreamToken, Query]) -> "StreamIterator":
     if isinstance(fql, Query):
       token = self.query(fql).data
     else:
@@ -390,7 +390,7 @@ class Client:
 
     return StreamIterator(self, token)
 
-  def _stream(self, token: StreamToken, start_ts: int | None):
+  def _stream(self, token: StreamToken, start_ts: Optional[int]):
     headers = self._headers.copy()
     headers[_Header.Format] = "tagged"
     headers[_Header.Authorization] = self._auth.bearer()

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -394,6 +394,21 @@ class Client:
       fql: Union[StreamToken, Query],
       opts: StreamOptions = StreamOptions()
   ) -> "StreamIterator":
+    """
+        Opens a Stream in Fauna and returns an iterator that consume Fauna events.
+
+        :param fql: A Query that returns a StreamToken or a StreamToken.
+        :param opts: (Optional) Stream Options.
+
+        :return: a :class:`StreamIterator`
+
+        :raises NetworkError: HTTP Request failed in transit
+        :raises ProtocolError: HTTP error not from Fauna
+        :raises ServiceError: Fauna returned an error
+        :raises ValueError: Encoding and decoding errors
+        :raises TypeError: Invalid param types
+        """
+
     if isinstance(fql, Query):
       token = self.query(fql).data
     else:

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -669,6 +669,10 @@ class StreamIterator:
         if event["type"] == "error":
           # todo: parse error
           raise StreamError
+
+        if event["type"] == "start":
+          return self._next_element()
+
         return event
 
       raise StopIteration

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -385,7 +385,7 @@ class Client:
       token = fql
 
     if not isinstance(token, StreamToken):
-      err_msg = f"'token' must be a StreamToken but was a {type(token)}."
+      err_msg = f"'fql' must be a StreamToken, or a Query that returns a StreamToken but was a {type(token)}."
       raise TypeError(err_msg)
 
     headers = self._headers.copy()
@@ -600,7 +600,7 @@ class Client:
 
 
 class StreamIterator:
-  """A class that mix a ContextManager and an Iterator so we can detected retryable errors."""
+  """A class that mixes a ContextManager and an Iterator so we can detected retryable errors."""
 
   def __init__(self, http_client, headers, endpoint, token):
     self.http_client = http_client

--- a/fauna/client/retryable.py
+++ b/fauna/client/retryable.py
@@ -62,7 +62,6 @@ class Retryable:
 
         Returns the number of attempts and the response
         """
-    err: Optional[RetryableFaunaException] = None
     attempt = 0
     while True:
       sleep_time = 0.0 if attempt == 0 else self._strategy.wait()

--- a/fauna/client/retryable.py
+++ b/fauna/client/retryable.py
@@ -2,7 +2,7 @@ import abc
 from dataclasses import dataclass
 from random import random
 from time import sleep
-from typing import Callable, Optional
+from typing import Callable, Optional, TypeVar, Generic
 
 from fauna.encoding import QuerySuccess
 from fauna.errors import RetryableFaunaException, ClientError
@@ -28,15 +28,18 @@ class ExponentialBackoffStrategy(RetryStrategy):
     return min(backoff, self._max_backoff)
 
 
+T = TypeVar('T')
+
+
 @dataclass
-class RetryableResponse:
+class RetryableResponse(Generic[T]):
   attempts: int
-  response: QuerySuccess
+  response: T
 
 
-class Retryable:
+class Retryable(Generic[T]):
   """
-    Retryable is a wrapper class that acts on a Callable that returns a QuerySuccess.
+    Retryable is a wrapper class that acts on a Callable that returns a T type.
     """
   _strategy: RetryStrategy
   _error: Optional[Exception]
@@ -45,7 +48,7 @@ class Retryable:
       self,
       max_attempts: int,
       max_backoff: int,
-      func: Callable[..., QuerySuccess],
+      func: Callable[..., T],
       *args,
       **kwargs,
   ):
@@ -56,7 +59,7 @@ class Retryable:
     self._kwargs = kwargs
     self._error = None
 
-  def run(self) -> RetryableResponse:
+  def run(self) -> RetryableResponse[T]:
     """Runs the wrapped function. Retries up to max_attempts if the function throws a RetryableFaunaException. It propagates
         the thrown exception if max_attempts is reached or if a non-retryable is thrown.
 
@@ -70,7 +73,7 @@ class Retryable:
       try:
         attempt += 1
         qs = self._func(*self._args, **self._kwargs)
-        return RetryableResponse(attempt, qs)
+        return RetryableResponse[T](attempt, qs)
       except RetryableFaunaException as e:
         if attempt >= self._max_attempts:
           raise e

--- a/fauna/encoding/decoder.py
+++ b/fauna/encoding/decoder.py
@@ -3,7 +3,7 @@ from typing import Any, List, Union
 from iso8601 import parse_date
 
 from fauna.query.models import Module, DocumentReference, Document, NamedDocument, NamedDocumentReference, Page, \
-    NullDocument
+    NullDocument, StreamToken
 
 
 class FaunaDecoder:
@@ -42,6 +42,8 @@ class FaunaDecoder:
      +--------------------+---------------+
      | Page               | @set          |
      +--------------------+---------------+
+     | StreamToken        | @stream       |
+     +--------------------+---------------+
 
      """
 
@@ -59,6 +61,7 @@ class FaunaDecoder:
             - { "@ref": ... } decodes to a DocumentReference or NamedDocumentReference
             - { "@mod": ... } decodes to a Module
             - { "@set": ... } decodes to a Page
+            - { "@stream": ... } decodes to a StreamToken
 
         :param obj: the object to decode
         """
@@ -164,5 +167,8 @@ class FaunaDecoder:
         data = FaunaDecoder._decode(value["data"]) if "data" in value else None
 
         return Page(data=data, after=after)
+
+      if "@stream" in dct:
+        return StreamToken(dct["@stream"])
 
     return {k: FaunaDecoder._decode(v) for k, v in dct.items()}

--- a/fauna/errors/__init__.py
+++ b/fauna/errors/__init__.py
@@ -3,4 +3,4 @@ from .errors import ClientError, FaunaError, NetworkError
 from .errors import ProtocolError, ServiceError
 from .errors import AuthenticationError, AuthorizationError, QueryCheckError, QueryRuntimeError, \
     QueryTimeoutError, ServiceInternalError, ServiceTimeoutError, ThrottlingError, ContendedTransactionError, \
-    InvalidRequestError, AbortError, RetryableFaunaException, StreamTimeout
+    InvalidRequestError, AbortError, RetryableFaunaException, StreamError

--- a/fauna/errors/__init__.py
+++ b/fauna/errors/__init__.py
@@ -3,4 +3,4 @@ from .errors import ClientError, FaunaError, NetworkError
 from .errors import ProtocolError, ServiceError
 from .errors import AuthenticationError, AuthorizationError, QueryCheckError, QueryRuntimeError, \
     QueryTimeoutError, ServiceInternalError, ServiceTimeoutError, ThrottlingError, ContendedTransactionError, \
-    InvalidRequestError, AbortError, RetryableFaunaException
+    InvalidRequestError, AbortError, RetryableFaunaException, StreamTimeout

--- a/fauna/errors/__init__.py
+++ b/fauna/errors/__init__.py
@@ -3,4 +3,4 @@ from .errors import ClientError, FaunaError, NetworkError
 from .errors import ProtocolError, ServiceError
 from .errors import AuthenticationError, AuthorizationError, QueryCheckError, QueryRuntimeError, \
     QueryTimeoutError, ServiceInternalError, ServiceTimeoutError, ThrottlingError, ContendedTransactionError, \
-    InvalidRequestError, AbortError, RetryableFaunaException, StreamError
+    InvalidRequestError, AbortError, RetryableFaunaException

--- a/fauna/errors/errors.py
+++ b/fauna/errors/errors.py
@@ -19,6 +19,11 @@ class ClientError(FaunaException):
   pass
 
 
+class StreamTimeout(FaunaException):
+  """An error representing Straming timeouts."""
+  pass
+
+
 class NetworkError(FaunaException):
   """An error representing a failure due to the network.
     This indicates Fauna was never reached."""

--- a/fauna/errors/errors.py
+++ b/fauna/errors/errors.py
@@ -21,7 +21,11 @@ class ClientError(FaunaException):
 
 class StreamError(FaunaException):
   """An error representing Stream failure."""
-  pass
+
+  def __init__(self, message, code, stats):
+    self.message = message
+    self.code = code
+    self.stats = stats
 
 
 class NetworkError(FaunaException):

--- a/fauna/errors/errors.py
+++ b/fauna/errors/errors.py
@@ -19,8 +19,8 @@ class ClientError(FaunaException):
   pass
 
 
-class StreamTimeout(FaunaException):
-  """An error representing Straming timeouts."""
+class StreamError(FaunaException):
+  """An error representing Stream failure."""
   pass
 
 

--- a/fauna/errors/errors.py
+++ b/fauna/errors/errors.py
@@ -1,6 +1,6 @@
 from typing import Optional, List, Any, Mapping
 
-from fauna.encoding import ConstraintFailure, QueryStats, QueryInfo
+from fauna.encoding import ConstraintFailure, QueryStats, QueryInfo, QueryTags
 
 
 class FaunaException(Exception):
@@ -17,15 +17,6 @@ class ClientError(FaunaException):
     This indicates Fauna was never called - the client failed internally
     prior to sending the request."""
   pass
-
-
-class StreamError(FaunaException):
-  """An error representing Stream failure."""
-
-  def __init__(self, message, code, stats):
-    self.message = message
-    self.code = code
-    self.stats = stats
 
 
 class NetworkError(FaunaException):
@@ -92,6 +83,201 @@ class FaunaError(FaunaException):
 
   def __str__(self):
     return f"{self.status_code}: {self.code}\n{self.message}"
+
+  @staticmethod
+  def parse_error_and_throw(body: Any, status_code: int):
+    err = body["error"]
+    code = err["code"]
+    message = err["message"]
+
+    query_tags = QueryTags.decode(
+        body["query_tags"]) if "query_tags" in body else None
+    stats = QueryStats(body["stats"]) if "stats" in body else None
+    txn_ts = body["txn_ts"] if "txn_ts" in body else None
+    schema_version = body["schema_version"] if "schema_version" in body else None
+    summary = body["summary"] if "summary" in body else None
+
+    constraint_failures: Optional[List[ConstraintFailure]] = None
+    if "constraint_failures" in err:
+      constraint_failures = [
+          ConstraintFailure(
+              message=cf["message"],
+              name=cf["name"] if "name" in cf else None,
+              paths=cf["paths"] if "paths" in cf else None,
+          ) for cf in err["constraint_failures"]
+      ]
+
+    if status_code >= 400 and status_code < 500:
+      if code == "invalid_query":
+        raise QueryCheckError(
+            status_code=400,
+            code=code,
+            message=message,
+            summary=summary,
+            constraint_failures=constraint_failures,
+            query_tags=query_tags,
+            stats=stats,
+            txn_ts=txn_ts,
+            schema_version=schema_version,
+        )
+      elif code == "invalid_request":
+        raise InvalidRequestError(
+            status_code=400,
+            code=code,
+            message=message,
+            summary=summary,
+            constraint_failures=constraint_failures,
+            query_tags=query_tags,
+            stats=stats,
+            txn_ts=txn_ts,
+            schema_version=schema_version,
+        )
+      elif code == "abort":
+        abort = err["abort"] if "abort" in err else None
+        raise AbortError(
+            status_code=400,
+            code=code,
+            message=message,
+            summary=summary,
+            abort=abort,
+            constraint_failures=constraint_failures,
+            query_tags=query_tags,
+            stats=stats,
+            txn_ts=txn_ts,
+            schema_version=schema_version,
+        )
+      elif code == "unauthorized":
+        raise AuthenticationError(
+            status_code=401,
+            code=code,
+            message=message,
+            summary=summary,
+            constraint_failures=constraint_failures,
+            query_tags=query_tags,
+            stats=stats,
+            txn_ts=txn_ts,
+            schema_version=schema_version,
+        )
+      elif code == "forbidden" and status_code == 403:
+        raise AuthorizationError(
+            status_code=403,
+            code=code,
+            message=message,
+            summary=summary,
+            constraint_failures=constraint_failures,
+            query_tags=query_tags,
+            stats=stats,
+            txn_ts=txn_ts,
+            schema_version=schema_version,
+        )
+      elif code == "method_not_allowed":
+        raise QueryRuntimeError(
+            status_code=405,
+            code=code,
+            message=message,
+            summary=summary,
+            constraint_failures=constraint_failures,
+            query_tags=query_tags,
+            stats=stats,
+            txn_ts=txn_ts,
+            schema_version=schema_version,
+        )
+      elif code == "conflict":
+        raise ContendedTransactionError(
+            status_code=409,
+            code=code,
+            message=message,
+            summary=summary,
+            constraint_failures=constraint_failures,
+            query_tags=query_tags,
+            stats=stats,
+            txn_ts=txn_ts,
+            schema_version=schema_version,
+        )
+      elif code == "request_size_exceeded":
+        raise QueryRuntimeError(
+            status_code=413,
+            code=code,
+            message=message,
+            summary=summary,
+            constraint_failures=constraint_failures,
+            query_tags=query_tags,
+            stats=stats,
+            txn_ts=txn_ts,
+            schema_version=schema_version,
+        )
+      elif code == "limit_exceeded":
+        raise ThrottlingError(
+            status_code=429,
+            code=code,
+            message=message,
+            summary=summary,
+            constraint_failures=constraint_failures,
+            query_tags=query_tags,
+            stats=stats,
+            txn_ts=txn_ts,
+            schema_version=schema_version,
+        )
+      elif code == "time_out":
+        raise QueryTimeoutError(
+            status_code=440,
+            code=code,
+            message=message,
+            summary=summary,
+            constraint_failures=constraint_failures,
+            query_tags=query_tags,
+            stats=stats,
+            txn_ts=txn_ts,
+            schema_version=schema_version,
+        )
+      else:
+        raise QueryRuntimeError(
+            status_code=status_code,
+            code=code,
+            message=message,
+            summary=summary,
+            constraint_failures=constraint_failures,
+            query_tags=query_tags,
+            stats=stats,
+            txn_ts=txn_ts,
+            schema_version=schema_version,
+        )
+    elif status_code == 500:
+      raise ServiceInternalError(
+          status_code=status_code,
+          code=code,
+          message=message,
+          summary=summary,
+          constraint_failures=constraint_failures,
+          query_tags=query_tags,
+          stats=stats,
+          txn_ts=txn_ts,
+          schema_version=schema_version,
+      )
+    elif status_code == 503:
+      raise ServiceTimeoutError(
+          status_code=status_code,
+          code=code,
+          message=message,
+          summary=summary,
+          constraint_failures=constraint_failures,
+          query_tags=query_tags,
+          stats=stats,
+          txn_ts=txn_ts,
+          schema_version=schema_version,
+      )
+    else:
+      raise ServiceError(
+          status_code=status_code,
+          code=code,
+          message=message,
+          summary=summary,
+          constraint_failures=constraint_failures,
+          query_tags=query_tags,
+          stats=stats,
+          txn_ts=txn_ts,
+          schema_version=schema_version,
+      )
 
 
 class ServiceError(FaunaError, QueryInfo):

--- a/fauna/http/http_client.py
+++ b/fauna/http/http_client.py
@@ -1,7 +1,7 @@
 import abc
 import contextlib
 
-from typing import Iterator, Mapping, Any
+from typing import Iterator, Mapping, Any, Optional
 from dataclasses import dataclass
 
 
@@ -69,6 +69,7 @@ class HTTPClient(abc.ABC):
       url: str,
       headers: Mapping[str, str],
       data: Mapping[str, Any],
+      timeout: Optional[float],
   ) -> Iterator[Any]:
     pass
 

--- a/fauna/http/http_client.py
+++ b/fauna/http/http_client.py
@@ -67,7 +67,7 @@ class HTTPClient(abc.ABC):
       url: str,
       headers: Mapping[str, str],
       data: Mapping[str, Any],
-  ) -> HTTPResponse:
+  ) -> Iterator[Any]:
     pass
 
   @abc.abstractmethod

--- a/fauna/http/http_client.py
+++ b/fauna/http/http_client.py
@@ -69,7 +69,6 @@ class HTTPClient(abc.ABC):
       url: str,
       headers: Mapping[str, str],
       data: Mapping[str, Any],
-      timeout: Optional[float],
   ) -> Iterator[Any]:
     pass
 

--- a/fauna/http/http_client.py
+++ b/fauna/http/http_client.py
@@ -1,4 +1,5 @@
 import abc
+import contextlib
 
 from typing import Iterator, Mapping, Any
 from dataclasses import dataclass
@@ -62,6 +63,7 @@ class HTTPClient(abc.ABC):
     pass
 
   @abc.abstractmethod
+  @contextlib.contextmanager
   def stream(
       self,
       url: str,

--- a/fauna/http/httpx_client.py
+++ b/fauna/http/httpx_client.py
@@ -1,6 +1,7 @@
 import json
 from json import JSONDecodeError
 from typing import Mapping, Any, Optional, Iterator
+from contextlib import contextmanager
 
 import httpx
 
@@ -93,16 +94,20 @@ class HTTPXClient(HTTPClient):
       else:
         return self._send_with_retry(retryCount - 1, request)
 
-  # todo: decorate with context manager
+  @contextmanager
   def stream(
       self,
       url: str,
       headers: Mapping[str, str],
       data: Mapping[str, Any],
   ) -> Iterator[Any]:
-    with self._c.stream("POST", url=url, headers=headers, json=data) as r:
-      for line in r.iter_lines():
-        yield json.loads(line)
+    with self._c.stream(
+        "POST", url=url, headers=headers, json=data) as response:
+      yield self._transform(response)
+
+  def _transform(self, response):
+    for line in response.iter_lines():
+      yield json.loads(line)
 
   def close(self):
     self._c.close()

--- a/fauna/http/httpx_client.py
+++ b/fauna/http/httpx_client.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 
 import httpx
 
-from fauna.errors import ClientError, NetworkError, StreamTimeout
+from fauna.errors import ClientError, NetworkError
 from fauna.http.http_client import HTTPResponse, HTTPClient
 
 
@@ -100,21 +100,17 @@ class HTTPXClient(HTTPClient):
       url: str,
       headers: Mapping[str, str],
       data: Mapping[str, Any],
-      timeout: Optional[float] = None,
   ) -> Iterator[Any]:
-    stream = self._c.stream(
-        "POST", url=url, headers=headers, json=data, timeout=timeout)
-    with stream as response:
+    with self._c.stream(
+        "POST", url=url, headers=headers, json=data) as response:
       yield self._transform(response)
 
   def _transform(self, response):
     try:
       for line in response.iter_lines():
         yield json.loads(line)
-    except httpx.StreamError as e:
-      raise StopIteration
     except httpx.ReadTimeout as e:
-      raise StreamTimeout("Stream timeout") from e
+      raise NetworkError("Stream timeout") from e
     except (httpx.HTTPError, httpx.InvalidURL) as e:
       raise NetworkError("Exception re-raised from HTTP request") from e
 

--- a/fauna/http/httpx_client.py
+++ b/fauna/http/httpx_client.py
@@ -93,13 +93,16 @@ class HTTPXClient(HTTPClient):
       else:
         return self._send_with_retry(retryCount - 1, request)
 
+  # todo: decorate with context manager
   def stream(
       self,
       url: str,
       headers: Mapping[str, str],
       data: Mapping[str, Any],
-  ) -> Iterator[HTTPResponse]:
-    raise NotImplementedError()
+  ) -> Iterator[Any]:
+    with self._c.stream("POST", url=url, headers=headers, json=data) as r:
+      for line in r.iter_lines():
+        yield json.loads(line)
 
   def close(self):
     self._c.close()

--- a/fauna/query/models.py
+++ b/fauna/query/models.py
@@ -30,10 +30,23 @@ class Page:
         other, Page) and self.data == other.data and self.after == other.after
 
   def __hash__(self):
-    hash((type(self), self.data, self.after))
+    return hash((type(self), self.data, self.after))
 
   def __ne__(self, other):
     return not self.__eq__(other)
+
+
+class StreamToken:
+  """A class represeting a Stream in Fauna."""
+
+  def __init__(self, token: str):
+    self.token = token
+
+  def __eq__(self, other):
+    return isinstance(other, StreamToken) and self.token == other.token
+
+  def __hash__(self):
+    return hash(self.token)
 
 
 class Module:
@@ -56,7 +69,7 @@ class Module:
     return isinstance(other, Module) and str(self) == str(other)
 
   def __hash__(self):
-    hash(self.name)
+    return hash(self.name)
 
 
 class BaseReference:
@@ -102,7 +115,7 @@ class DocumentReference(BaseReference):
     self._id = id
 
   def __hash__(self):
-    hash((type(self), self._collection, self._id))
+    return hash((type(self), self._collection, self._id))
 
   def __repr__(self):
     return f"{self.__class__.__name__}(id={repr(self._id)},coll={repr(self._collection)})"
@@ -136,7 +149,7 @@ class NamedDocumentReference(BaseReference):
     self._name = name
 
   def __hash__(self):
-    hash((type(self), self._collection, self._name))
+    return hash((type(self), self._collection, self._name))
 
   def __repr__(self):
     return f"{self.__class__.__name__}(name={repr(self._name)},coll={repr(self._collection)})"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,11 +6,16 @@ import pytest
 
 from fauna import fql, Module
 from fauna.client import Client
+from fauna.client.utils import _Environment
 from fauna.query import Query
 
 
 def create_collection(name) -> Query:
   return fql('Collection.create({ name: ${name} })', name=name)
+
+
+def create_database(name) -> Query:
+  return fql('Database.create({ name: ${name} })', name=name)
 
 
 @pytest.fixture
@@ -22,6 +27,18 @@ def suffix() -> str:
 @pytest.fixture(scope="module")
 def client() -> Client:
   return Client()
+
+
+@pytest.fixture
+def scoped_client(scoped_secret) -> Client:
+  return Client(secret=scoped_secret)
+
+
+@pytest.fixture
+def scoped_secret(client, suffix) -> str:
+  db_name = f"Test_{suffix}"
+  client.query(create_database(db_name))
+  return f"{_Environment.EnvFaunaSecret()}:{db_name}:admin"
 
 
 @pytest.fixture

--- a/tests/integration/test_client_with_query_limits.py
+++ b/tests/integration/test_client_with_query_limits.py
@@ -9,7 +9,7 @@ from fauna.encoding import QuerySuccess
 from fauna.errors.errors import ThrottlingError
 
 
-def query_collection(client: Client) -> QuerySuccess:
+def query_collection(client: Client) -> QuerySuccess | None:
   coll_name = os.environ.get("QUERY_LIMITS_COLL") or ""
   try:
     return client.query(fql("${coll}.all().paginate(50)", coll=fql(coll_name)))

--- a/tests/integration/test_client_with_query_limits.py
+++ b/tests/integration/test_client_with_query_limits.py
@@ -1,4 +1,5 @@
 from multiprocessing.pool import ThreadPool
+from typing import Optional
 import os
 
 import pytest
@@ -9,7 +10,7 @@ from fauna.encoding import QuerySuccess
 from fauna.errors.errors import ThrottlingError
 
 
-def query_collection(client: Client) -> QuerySuccess | None:
+def query_collection(client: Client) -> Optional[QuerySuccess]:
   coll_name = os.environ.get("QUERY_LIMITS_COLL") or ""
   try:
     return client.query(fql("${coll}.all().paginate(50)", coll=fql(coll_name)))

--- a/tests/integration/test_stream.py
+++ b/tests/integration/test_stream.py
@@ -27,7 +27,7 @@ def test_stream(client, a_collection):
     stream = client.stream(fql("${coll}.all().toStream()", coll=a_collection))
 
     with stream as iter:
-      events[0] = [evt["type"] for evt in take(iter, 4)]
+      events[0] = [evt["type"] for evt in take(iter, 3)]
 
   stream_thread = threading.Thread(target=thread_fn)
   stream_thread.start()
@@ -37,7 +37,7 @@ def test_stream(client, a_collection):
   client.query(fql("${coll}.create({}).id", coll=a_collection))
 
   stream_thread.join()
-  assert events[0] == ["start", "add", "remove", "add"]
+  assert events[0] == ["add", "remove", "add"]
 
 
 def test_close_method(client, a_collection):
@@ -62,7 +62,7 @@ def test_close_method(client, a_collection):
   client.query(fql("${coll}.create({}).id", coll=a_collection)).data
 
   stream_thread.join()
-  assert events == ["start", "add"]
+  assert events == ["add", "add"]
 
 
 def test_max_retries(a_collection):

--- a/tests/integration/test_stream.py
+++ b/tests/integration/test_stream.py
@@ -1,0 +1,54 @@
+import threading
+from datetime import timedelta
+
+import pytest
+
+from fauna import fql
+from fauna.client import StreamOptions
+
+
+def test_stream(client, a_collection):
+
+  opts = StreamOptions(
+      idle_timeout=timedelta(seconds=1), retry_on_timeout=False)
+
+  def thread_fn():
+    stream = client.stream(
+        fql("${coll}.all().toStream()", coll=a_collection), opts)
+
+    with stream as iter:
+      events = [evt["type"] for evt in iter]
+
+    assert events == ["start", "add", "remove", "add"]
+
+  stream_thread = threading.Thread(target=thread_fn)
+  stream_thread.start()
+
+  id = client.query(fql("${coll}.create({}).id", coll=a_collection)).data
+  client.query(fql("${coll}.byId(${id})!.delete()", coll=a_collection, id=id))
+  client.query(fql("${coll}.create({}).id", coll=a_collection))
+
+  stream_thread.join()
+
+
+def test_retry_on_timeout(client, a_collection):
+
+  opts = StreamOptions(
+      idle_timeout=timedelta(seconds=0.1), retry_on_timeout=True)
+
+  def thread_fn():
+    stream = client.stream(
+        fql("${coll}.all().toStream()", coll=a_collection), opts)
+
+    events = []
+    with stream as iter:
+      for evt in iter:
+        events.append(evt["type"])
+        if len(events) == 4:
+          iter.close()
+
+    assert events == ["start", "start", "start", "start"]
+
+  stream_thread = threading.Thread(target=thread_fn)
+  stream_thread.start()
+  stream_thread.join()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -442,7 +442,7 @@ def test_client_close_stream(subtests, httpx_mock: HTTPXMock):
     http_client = HTTPXClient(mockClient)
     c = Client(http_client=http_client)
     with c.stream(StreamToken("token")) as stream:
-      next(stream) == 10
+      assert next(stream) == 10
       stream.close()
 
       with pytest.raises(StopIteration):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -480,7 +480,7 @@ def test_client_close_stream_on_error(subtests, httpx_mock: HTTPXMock):
   def stream_iter():
     yield b'{"type": "start", "ts": 1}\n'
     yield b'{"type": "add", "ts": 2}\n'
-    yield b'{"type": "error", "ts": 3}\n'
+    yield b'{"type": "error", "ts": 3, "message": "message", "code": "code"}\n'
     yield b'{"type": "start", "ts": 4}\n'
 
   httpx_mock.add_response(stream=IteratorStream(stream_iter()))

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -7,7 +7,7 @@ import pytest
 from fauna import fql
 from fauna.encoding import FaunaEncoder, FaunaDecoder
 from fauna.query.models import DocumentReference, NamedDocumentReference, Document, NamedDocument, Module, Page, \
-    NullDocument
+    NullDocument, StreamToken
 
 fixed_datetime = datetime.fromisoformat("2023-03-17T00:00:00+00:00")
 
@@ -776,3 +776,17 @@ def test_encode_query_builder_sub_queries(subtests):
     }
 
     assert expected == actual
+
+
+def test_decode_stream(subtests):
+  with subtests.test(msg="decode @stream into StreamToken"):
+    test = {"@stream": "asdflkj"}
+    decoded = FaunaDecoder.decode(test)
+    assert decoded == StreamToken("asdflkj")
+
+
+def test_encode_stream(subtests):
+  with subtests.test(msg="encode StreamToken into @stream"):
+    test = {"@stream": "asdflkj"}
+    encoded = FaunaEncoder.encode(StreamToken("asdflkj"))
+    assert encoded == test

--- a/tests/unit/test_httpx_client.py
+++ b/tests/unit/test_httpx_client.py
@@ -1,0 +1,23 @@
+import json
+
+import httpx
+from pytest_httpx import HTTPXMock, IteratorStream
+
+from fauna.client import Client
+from fauna.http import HTTPXClient
+
+
+def test_httx_client_stream(subtests, httpx_mock: HTTPXMock):
+  expected = [{"@int": "10"}, {"@long": "20"}]
+
+  def to_json_bytes(obj):
+    return bytes(json.dumps(obj) + "\n", "utf-8")
+
+  httpx_mock.add_response(
+      stream=IteratorStream([to_json_bytes(obj) for obj in expected]))
+
+  with httpx.Client() as mockClient:
+    http_client = HTTPXClient(mockClient)
+    ret = [obj for obj in http_client.stream("http://localhost:8443", {}, {})]
+
+    assert ret == expected

--- a/tests/unit/test_httpx_client.py
+++ b/tests/unit/test_httpx_client.py
@@ -37,7 +37,7 @@ def test_httx_client_close_stream(subtests, httpx_mock: HTTPXMock):
   with httpx.Client() as mockClient:
     http_client = HTTPXClient(mockClient)
     with http_client.stream("http://localhost:8443", {}, {}) as stream:
-      next(stream) == expected[0]
+      assert next(stream) == expected[0]
       stream.close()
 
       with pytest.raises(StopIteration):

--- a/tests/unit/test_httpx_client.py
+++ b/tests/unit/test_httpx_client.py
@@ -1,6 +1,7 @@
 import json
 
 import httpx
+import pytest
 from pytest_httpx import HTTPXMock, IteratorStream
 
 from fauna.client import Client
@@ -18,6 +19,26 @@ def test_httx_client_stream(subtests, httpx_mock: HTTPXMock):
 
   with httpx.Client() as mockClient:
     http_client = HTTPXClient(mockClient)
-    ret = [obj for obj in http_client.stream("http://localhost:8443", {}, {})]
+    with http_client.stream("http://localhost:8443", {}, {}) as stream:
+      ret = [obj for obj in stream]
 
-    assert ret == expected
+      assert ret == expected
+
+
+def test_httx_client_close_stream(subtests, httpx_mock: HTTPXMock):
+  expected = [{"@int": "10"}, {"@long": "20"}]
+
+  def to_json_bytes(obj):
+    return bytes(json.dumps(obj) + "\n", "utf-8")
+
+  httpx_mock.add_response(
+      stream=IteratorStream([to_json_bytes(obj) for obj in expected]))
+
+  with httpx.Client() as mockClient:
+    http_client = HTTPXClient(mockClient)
+    with http_client.stream("http://localhost:8443", {}, {}) as stream:
+      next(stream) == expected[0]
+      stream.close()
+
+      with pytest.raises(StopIteration):
+        next(stream)


### PR DESCRIPTION
ENG-6011, ENG-6012, ENG-6013, ENG-6014, ENG-6039

With this PR we are already able to support the following snippet of code:
```
from fauna import fql
from fauna.client import Client

client = Client(endpoint = "http://localhost:8443", secret = "secret")

token = client.query(fql('Products.all().toStream()'))

with client.stream(token.data) as stream:
  for evt in stream:
    print(evt)

    if some_condition:
      stream.close()
```