### PR TITLE
[DOCS-2635] Document `Client.paginate()`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,6 +270,40 @@ Stats are returned on query responses and ServiceErrors.
             emit_stats(e.stats)
         # more error handling...
 
+Pagination
+------------------
+
+Use the ``Client.paginate()`` method to iterate sets that contain more than one
+page of results.
+
+``Client.paginate()`` accepts the same query options as ``Client.query()``.
+
+Change the default items per page using FQL's ``<set>.pageSize()`` method.
+
+.. code-block:: python
+
+    from datetime import timedelta
+    from fauna import fql
+    from fauna.client import Client, QueryOptions
+
+    # Adjust `pageSize()` size as needed.
+    query = fql(
+        """
+        Product
+            .byName("limes")
+            .pageSize(60) { description }"""
+    )
+
+    client = Client()
+
+    options = QueryOptions(query_timeout=timedelta(seconds=20))
+
+    pages = client.paginate(query, options)
+
+    for products in pages:
+        for product in products:
+            print(products)
+
 Event Streaming
 ------------------
 


### PR DESCRIPTION
Ticket(s): [DOCS-2635)](https://faunadb.atlassian.net/browse/DOCS-2635)

## Problem

We don't currently document the `Client.paginate()` method.

## Solution

Add documentation to the README.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

