### PR TITLE
[DOCS-2647] Document `<stream>.close()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,34 @@ _Stream events iterator_
 
 The stream method returns an iterator that can be used to provide the events as they happen.  See above examples for using the iterator to process events.
 
+_Close a stream_
+
+Use the `<stream>.close()` method to close a stream.
+
+```python
+import fauna
+
+from fauna import fql
+from fauna.client import Client
+
+client = Client()
+
+events = []
+
+with client.stream(fql(
+  'Product.all().where(.price > 50).toStream() { name, price, category }'
+)) as stream:
+  for event in stream:
+    print(event["type"])
+    print(event["data"])
+
+    events.append(event)
+    # Close the stream after 2 events
+    if len(events) == 2:
+      print("Closing the stream ...")
+      stream.close()
+```
+
 _Error Handling_
 
 If a non retryable error occurs as part of stream processing, or when attempting to open a stream, a FaunaException will be raised. This can be handled as follows:


### PR DESCRIPTION
Ticket(s): [DOCS-2647](https://faunadb.atlassian.net/browse/DOCS-2647)

## Problem

The `<stream>.close()` method for Event Streaming is undocumented.

## Solution

Documents the method.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



[DOCS-2647]: https://faunadb.atlassian.net/browse/DOCS-2647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ