### PR TITLE
Remove beta release steps

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -11,13 +11,6 @@ resources:
     source:
       url: ((slack-webhook))
 
-  - name: beta.git
-    type: git
-    icon: github
-    source:
-      uri: https://github.com/fauna/fauna-python
-      branch: beta
-
   - name: fauna-python-repository
     type: git
     icon: github
@@ -56,15 +49,12 @@ groups:
       - set-self
       - test
       - release
-      - test-beta
-      - release-beta
 
 jobs:
   - name: set-self
     plan:
       - get: fauna-python-repository
         trigger: true
-      - get: beta.git
       - set_pipeline: self
         file: fauna-python-repository/concourse/pipeline.yml
 
@@ -143,72 +133,3 @@ jobs:
       - put: fauna-python-repository-docs
         params:
           repository: fauna-python-repository-updated-docs
-
-  - name: test-beta
-    serial: true
-    plan:
-      - get: beta.git
-        passed:
-          - set-self
-      - get: testtools-repo
-      - get: testtools-image
-
-      - load_var: git-commit
-        reveal: true
-        file: beta.git/.git/ref
-
-      - in_parallel:
-          fail_fast: false
-          steps:
-            - task: unit-and-integration-tests
-              file: beta.git/concourse/tasks/tests.yml
-              privileged: true
-
-            - task: aws-lambda-tests
-              image: testtools-image
-              file: testtools-repo/fauna-driver-platform-tests/concourse/tasks/python-aws-lambda-tests.yml
-              params:
-                GIT_COMMIT: ((.:git-commit))
-                FAUNA_SECRET: ((drivers-platform-tests/fauna-secret))
-                AWS_LAMBDA_ROLE_ARN: ((drivers-platform-tests/aws-lambda-role-arn))
-                AWS_ACCESS_KEY_ID: ((drivers-platform-tests/aws-access-key-id))
-                AWS_SECRET_ACCESS_KEY: ((drivers-platform-tests/aws-secret-key))
-
-            - task: vercel-tests
-              image: testtools-image
-              file: testtools-repo/fauna-driver-platform-tests/concourse/tasks/python-vercel-tests.yml
-              params:
-                GIT_COMMIT: ((.:git-commit))
-                FAUNA_SECRET: ((drivers-platform-tests/fauna-secret))
-                VERCEL_TOKEN: ((drivers-platform-tests/vercel-token))
-
-            - task: query-limits-tests
-              privileged: true
-              file: beta.git/concourse/tasks/query-limits-tests.yml
-              params:
-                QUERY_LIMITS_DB: limited
-                QUERY_LIMITS_COLL: limitCollection
-
-
-  - name: release-beta
-    serial: true
-    public: false
-    plan:
-      - get: beta.git
-        passed:
-          - set-self
-
-      - task: build
-        file: beta.git/concourse/tasks/build.yml
-        input_mapping: {fauna-python-repository: beta.git }
-
-      - task: publish
-        file: beta.git/concourse/tasks/publish.yml
-        input_mapping: {fauna-python-repository: beta.git }
-        params:
-          TWINE_USERNAME: ((pypi-username))
-          TWINE_PASSWORD: ((pypi-password))
-        on_success:
-          put: notify
-          params:
-            text_file: slack-message/publish


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

## Problem
We no longer want to release beta versions of the driver. Instead, we'll likely gate beta features via configuration.

## Solution
Remove it from the pipeline.

## Result

## Testing
None


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

