### PR TITLE
[DOCS-3220] Cross-link to driver API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ The following versions of Python are supported:
 * Python 3.12
 
 
+## API reference
+
+API reference documentation for the driver is available at
+https://fauna.github.io/fauna-python/. The docs are generated using
+[pdoc](https://pdoc.dev/docs/pdoc.html).
+
+
 ## Basic Usage
 You can expect a ``Client`` instance to have reasonable defaults, like the Fauna endpoint ``https://db.fauna.com`` and a global HTTP client, but you will always need to configure a secret.
 

--- a/concourse/scripts/publish_docs.sh
+++ b/concourse/scripts/publish_docs.sh
@@ -34,6 +34,9 @@ cd fauna-python-repository-updated-docs
 mkdir -p "${PACKAGE_VERSION}/api/"
 cp -R ../docs/* "./${PACKAGE_VERSION}/api/"
 
+echo "Updating 'latest' symlink to point to $PACKAGE_VERSION"
+ln -sfn "$PACKAGE_VERSION" latest
+
 git config --global user.email "nobody@fauna.com"
 git config --global user.name "Fauna, Inc"
 


### PR DESCRIPTION
Ticket(s): [DOCS-3241](https://faunadb.atlassian.net/browse/DOCS-3241)

## Problem

- We don't link to the driver API reference from the README. Users may not be aware these docs exist.
- I recently added a `latest/` symlink to the `gh-pages` branch that points to the latest release of the API ref. However, that symlink isn't updated as part of the release process.

## Solution

- Link to the API ref in the README.
- Update the `latest/` symlink in the `gh-pages` branch as part of release.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



[DOCS-3241]: https://faunadb.atlassian.net/browse/DOCS-3241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ