### PR TITLE
Only use http1.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,16 +30,16 @@ jobs:
         run: ulimit -a
 
       - name: Build docker
-        run: docker-compose -f docker/docker-compose.yml build --build-arg BASE_IMG=python:${{ matrix.python-version }} --no-cache
+        run: docker compose -f docker/docker-compose.yml build --build-arg BASE_IMG=python:${{ matrix.python-version }} --no-cache
 
       - name: Run unit tests
-        run: docker-compose -f docker/docker-compose.yml run --rm unit-test
+        run: docker compose -f docker/docker-compose.yml run --rm unit-test
 
       - name: Run integration tests
-        run: docker-compose -f docker/docker-compose.yml run --rm integration-test
+        run: docker compose -f docker/docker-compose.yml run --rm integration-test
 
       - name: Generate coverage html report with dynamic contexts
-        run: docker-compose -f docker/docker-compose.yml run --rm coverage
+        run: docker compose -f docker/docker-compose.yml run --rm coverage
 
       - uses: actions/upload-artifact@v3
         with:

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -180,8 +180,8 @@ class Client:
         from fauna.http.httpx_client import HTTPXClient
         c = HTTPXClient(
             httpx.Client(
-                http1=False,
-                http2=True,
+                http1=True,
+                http2=False,
                 timeout=httpx.Timeout(
                     timeout=timeout_s,
                     connect=connect_timeout_s,

--- a/fauna/http/httpx_client.py
+++ b/fauna/http/httpx_client.py
@@ -73,26 +73,12 @@ class HTTPXClient(HTTPClient):
       raise ClientError("Invalid URL Format") from e
 
     try:
-      return HTTPXResponse(self._send_with_retry(3, request))
-    except (httpx.HTTPError, httpx.InvalidURL) as e:
-      raise NetworkError("Exception re-raised from HTTP request") from e
-
-  def _send_with_retry(
-      self,
-      retryCount: int,
-      request: httpx.Request,
-  ) -> httpx.Response:
-    try:
-      response = self._c.send(
+      return HTTPXResponse(self._c.send(
           request,
           stream=False,
-      )
-      return response
-    except httpx.TransportError as e:
-      if retryCount == 0:
-        raise e
-      else:
-        return self._send_with_retry(retryCount - 1, request)
+      ))
+    except (httpx.HTTPError, httpx.InvalidURL) as e:
+      raise NetworkError("Exception re-raised from HTTP request") from e
 
   @contextmanager
   def stream(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Force HTTPX Client to use HTTP 1.1
* Do not automatically retry transport errors

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
Regarding HTTP 1.1., the [h2 library has a bug](https://github.com/python-hyper/h2/issues/1181) that mishandles the HTTP2 protocol for GOAWAY frames. When it receives a GOAWAY, in progress streams are not allowed to complete. This means any time our edge issues a GOAWAY an in progress request will throw even if Fauna handled it correctly.

The automatic retry was causing the client to resend the query. This is an unsafe retry because the client doesn't know whether Fauna ran the query.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Our edge issues a GOAWAY consistently at 10000 requests. We observed this behavior with HTTP/2 enabled and not when disabled.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [X] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


