### PR TITLE
ENG-6679: Introduce support for changefeeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,9 +411,7 @@ client.stream(fql('Product.all().toStream()'), options)
 
 ## Change Feeds (beta)
 
-<!-- TODO: turn "Change Feeds" into a link when available. -->
-
-The driver supports Change Feeds.
+The driver supports [Change Feeds](https://docs.fauna.com/fauna/current/learn/track-changes/streaming/#change-feeds).
 
 ### Request a Change Feed
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "8443:8443"
     volumes:
       - ../docker/feature-flags.json:/etc/feature-flag-periodic.d/feature-flags.json
+    environment:
+      - FLAG_ACCOUNT_CHANGE_FEEDS=true
   test:
     image: fauna-python-test:latest
     build:

--- a/docker/feature-flags.json
+++ b/docker/feature-flags.json
@@ -9,7 +9,8 @@
         "fqlx_typecheck_default": true,
         "persisted_fields": true,
         "changes_by_collection_index": true,
-        "fql2_streams": true
+        "fql2_streams": true,
+        "change_feeds": true
       }
     },
     {
@@ -20,7 +21,8 @@
         "fqlx_typecheck_default": true,
         "persisted_fields": true,
         "changes_by_collection_index": true,
-        "fql2_streams": true
+        "fql2_streams": true,
+        "change_feeds": true
       }
     }
   ]

--- a/docker/feature-flags.json
+++ b/docker/feature-flags.json
@@ -5,25 +5,7 @@
       "property_name": "cluster_name",
       "property_value": "fauna",
       "flags": {
-        "fql2_schema": true,
-        "fqlx_typecheck_default": true,
-        "persisted_fields": true,
-        "changes_by_collection_index": true,
-        "fql2_streams": true,
-        "change_feeds": true
       }
     },
-    {
-      "property_name": "account_id",
-      "property_value": 0,
-      "flags": {
-        "fql2_schema": true,
-        "fqlx_typecheck_default": true,
-        "persisted_fields": true,
-        "changes_by_collection_index": true,
-        "fql2_streams": true,
-        "change_feeds": true
-      }
-    }
   ]
 }

--- a/fauna/client/__init__.py
+++ b/fauna/client/__init__.py
@@ -1,3 +1,3 @@
-from .client import Client, QueryOptions, StreamOptions
+from .client import Client, QueryOptions, StreamOptions, ChangeFeedOptions
 from .endpoints import Endpoints
 from .headers import Header

--- a/tests/docker-compose-tests.yml
+++ b/tests/docker-compose-tests.yml
@@ -6,6 +6,10 @@ services:
     container_name: faunadb
     ports:
       - "8443:8443"
+    volumes:
+      - ../docker/feature-flags.json:/etc/feature-flag-periodic.d/feature-flags.json
+    environment:
+      - FLAG_ACCOUNT_CHANGE_FEEDS=true
     healthcheck:
       test: ["CMD", "curl", "http://faunadb:8443/ping"]
       interval: 1s

--- a/tests/integration/test_change_feeds.py
+++ b/tests/integration/test_change_feeds.py
@@ -1,0 +1,142 @@
+import time
+import pytest
+
+from fauna import fql
+from fauna.client import ChangeFeedOptions
+from fauna.errors import AbortError
+
+
+def test_change_feed_requires_stream(client, a_collection):
+  with pytest.raises(
+      TypeError,
+      match="'fql' must be a StreamToken, or a Query that returns a StreamToken but was a <class 'int'>."
+  ):
+    client.change_feed(fql("42"))
+
+
+def test_change_feed_query(client, a_collection):
+  feed = client.change_feed(fql("${col}.all().toStream()", col=a_collection))
+  _pull_one_event(client, a_collection, feed)
+
+
+def test_change_feed_token(client, a_collection):
+  token = client.query(fql("${col}.all().toStream()", col=a_collection)).data
+  feed = client.change_feed(token)
+  _pull_one_event(client, a_collection, feed)
+
+
+def _pull_one_event(client, col, feed):
+  client.query(fql("${col}.create({ foo: 'bar' })", col=col))
+
+  pages = list(feed)
+  assert len(pages) == 1
+  assert len(pages[0]) == 1
+
+  events = list(pages[0])
+  assert events[0]['type'] == 'add'
+  assert events[0]['data']['foo'] == 'bar'
+
+
+def test_change_feeds_error_event(client, a_collection):
+  feed = client.change_feed(
+      fql("${col}.all().map(_ => abort('oops')).toStream()", col=a_collection))
+
+  client.query(fql("${col}.create({ foo: 'bar' })", col=a_collection))
+
+  with pytest.raises(AbortError):
+    list(feed.flatten())
+
+
+@pytest.mark.xfail(reason="pending core support")
+def test_change_feeds_continue_after_an_error(client, a_collection):
+  feed = client.change_feed(
+      fql('''
+      ${col}
+        .all()
+        .map(doc =>
+          if (doc.n == 1) abort('oops')
+          else doc
+        )
+        .toStream()
+      ''',
+          col=a_collection))
+
+  client.query(
+      fql('''
+      Set
+        .sequence(0, 3)
+        .forEach(n => ${col}.create({ n: n }))
+      ''',
+          col=a_collection))
+
+  events = []
+
+  for page in feed:
+    try:
+      for event in page:
+        events.append(event['data']['n'])
+    except AbortError:
+      pass
+
+  assert events == [0, 2]
+
+
+def test_change_feed_start_ts(client, a_collection):
+  token = client.query(
+      fql("${col}.all().map(.n).toStream()", col=a_collection)).data
+
+  # NB. Issue separate queries to ensure they get different txn times.
+  _create_docs(client, a_collection, 0, 1)
+  _create_docs(client, a_collection, 1, 64)
+
+  # NB. Use a short page size to ensure that more than one roundtrip is made,
+  # thus testing the interator's internal cursoring is correct.
+  first = next(client.change_feed(token).flatten())
+  opts = ChangeFeedOptions(start_ts=first['txn_ts'], page_size=5)
+  feed = client.change_feed(token, opts)
+
+  nums = [event['data'] for event in feed.flatten()]
+  assert nums == list(range(1, 64))
+
+
+def test_change_feed_cursor(client, a_collection):
+  token = client.query(
+      fql("${col}.all().map(.n).toStream()", col=a_collection)).data
+
+  _create_docs(client, a_collection, 0, 64)
+
+  # NB. Use a short page size to ensure that more than one roundtrip is made,
+  # thus testing the interator's internal cursoring is correct.
+  first = next(client.change_feed(token).flatten())
+  opts = ChangeFeedOptions(cursor=first['cursor'], page_size=5)
+  feed = client.change_feed(token, opts)
+
+  nums = [event['data'] for event in feed.flatten()]
+  assert nums == list(range(1, 64))
+
+
+def test_change_feed_reusable_iterator(client, a_collection):
+  feed = client.change_feed(
+      fql("${col}.all().map(.n).toStream()", col=a_collection))
+
+  _create_docs(client, a_collection, 0, 5)
+  nums = [event['data'] for event in feed.flatten()]
+  assert nums == list(range(0, 5))
+
+  _create_docs(client, a_collection, 5, 10)
+  nums = [event['data'] for event in feed.flatten()]
+  assert nums == list(range(5, 10))
+
+
+def _create_docs(client, col, start=0, end=1):
+  client.query(
+      fql(
+          '''
+      Set
+        .sequence(${start}, ${end})
+        .forEach(n => ${col}.create({ n: n }))
+      ''',
+          start=start,
+          end=end,
+          col=col,
+      ))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description

Add changefeeds support to the Python driver.

### Motivation and context

Changefeeds allows to interactively poll from a stream instead of having it open at all times. It's useful for cron jobs and other forms of periodic tasks to sync 3rd party systems.

### How was the change tested?

Unit tests are included.

### Screenshots (if appropriate):

NA

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [X] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [X] My change requires a change to Fauna documentation.
* - [X] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


