### PR TITLE
[DOCS-3543] docs: Add (current) to README h1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Official Python Driver for [Fauna](https://fauna.com).
+# Official Python Driver for [Fauna v10](https://fauna.com) (current)
 
 [![Pypi Version](https://img.shields.io/pypi/v/fauna.svg?maxAge=21600)](https://pypi.python.org/pypi/fauna)
 [![License](https://img.shields.io/badge/license-MPL_2.0-blue.svg?maxAge=2592000)](https://raw.githubusercontent.com/fauna/fauna-python/main/LICENSE)


### PR DESCRIPTION
### Description
Adds `v10` and `(current)` to the README's h1.

### Motivation and context
* Improve SEO rankings for the v10 driver
* Align with other driver READMEs (See [JS driver](https://github.com/fauna/fauna-js/commit/80b897eba674b965d5efc64a2897cf9c0db265f9))

Fauna employees can see this [Slack discussion](https://faunadb.slack.com/archives/C0CST4800/p1728278226237289).

### How was the change tested?
N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


