### PR TITLE
feat: add debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,23 @@ options = ChangeFeedOptions(
 client.change_feed(fql('Product.all().toStream()'), options)
 ```
 
+## Logging
+
+Debug logging is handled by the standard logging package in under the `fauna` namespace. We will log the request with body, excluding the Authorization header, as well as the full response.
+
+In your application, you can enable debug logging with the following. Given this is a standard convention in Python, you may want more fine-grained control over which libraries log. See Python's how-to at https://docs.python.org/3/howto/logging.html.
+```python
+import logging
+from fauna.client import Client
+from fauna import fql
+
+logging.basicConfig(
+    level=logging.DEBUG
+)
+c = Client()
+c.query(fql("42"))
+```
+
 ## Setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -570,9 +570,9 @@ client.change_feed(fql('Product.all().toStream()'), options)
 
 ## Logging
 
-Debug logging is handled by the standard logging package in under the `fauna` namespace. We will log the request with body, excluding the Authorization header, as well as the full response.
+Logging is handled using Python's standard `logging` package under the `fauna` namespace. Logs include the HTTP request with body (excluding the `Authorization` header) and the full HTTP response.
 
-In your application, you can enable debug logging with the following. Given this is a standard convention in Python, you may want more fine-grained control over which libraries log. See Python's how-to at https://docs.python.org/3/howto/logging.html.
+To enable logging:
 ```python
 import logging
 from fauna.client import Client
@@ -581,9 +581,10 @@ from fauna import fql
 logging.basicConfig(
     level=logging.DEBUG
 )
-c = Client()
-c.query(fql("42"))
+client = Client()
+client.query(fql('42'))
 ```
+For configuration options or to set specific log levels, see Python's [Logging HOWTO](https://docs.python.org/3/howto/logging.html).
 
 ## Setup
 

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -446,7 +446,6 @@ class Client:
       if opts.cursor is not None:
         raise ClientError(
             "The 'cursor' configuration can only be used with a stream token.")
-
       token = self.query(fql).data
     else:
       token = fql

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Dict, Iterator, Mapping, Optional, Union, List
@@ -13,6 +14,8 @@ from fauna.errors import FaunaError, ClientError, ProtocolError, \
 from fauna.http.http_client import HTTPClient
 from fauna.query import Query, Page, fql
 from fauna.query.models import StreamToken
+
+logger = logging.getLogger("fauna")
 
 DefaultHttpConnectTimeout = timedelta(seconds=5)
 DefaultHttpReadTimeout: Optional[timedelta] = None
@@ -217,7 +220,7 @@ class Client:
                     max_keepalive_connections=DefaultMaxIdleConnections,
                     keepalive_expiry=idle_timeout_s,
                 ),
-            ))
+            ), logger)
         fauna.global_http_client = c
 
       self._session = fauna.global_http_client


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Adds debugging logging using standard logging package
  * Raw requests including body, but excluding the Authorization header are logged
  * Raw responses are logged

Enable debug logging with:
```python
import logging
from fauna.client import Client
from fauna import fql

logging.basicConfig(
    level=logging.DEBUG
)
c = Client()
c.query(fql("42"))
```

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
BT-5156

When users encounter unexpected behaviors they may need to inspect raw headers and data.

Why not a special env var named FAUNA_DEBUG? While we're doing this in other languages, it breaks a standard within Python that is intended to be configurable by logging namespace. Following the standard enables library consumers maximum control over logging within their applications without special treatment.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`httpcore` and `httpx` debug logs are excluded below for clarity.
```
DEBUG:fauna:query.request method=POST url=http://localhost:8443/query/1 headers=Headers({'host': 'localhost:8443', 'accept': '*/*', 'connection': 'keep-alive', 'user-agent': 'python-httpx/0.27.0', 'accept-encoding': 'gzip', 'content-type': 'application/json;charset=utf-8', 'x-driver': 'python', 'x-driver-env': 'driver=python-2.2.0; runtime=python-3.11.7-final env=unknown; os=darwin-23.6.0', 'x-format': 'tagged', 'x-query-timeout-ms': '5000', 'content-length': '79'}) data={'query': {'fql': ["Collection.byName('Product')?.delete()"]}, 'arguments': {}}

DEBUG:fauna:query.response status_code=200 headers=Headers({'x-faunadb-build': '24.09.04-1d6ea0d', 'connection': 'keep-alive', 'traceparent': '00-4ddb9c1b995a45dcda7a4f23d04a7608-3e6c82a6b607df94-00', 'content-length': '340', 'content-type': 'application/json;charset=utf-8'}) data={"data":{"@ref":{"name":"Product","coll":{"@mod":"Collection"},"exists":false,"cause":"deleted"}},"summary":"","txn_ts":1728562773960000,"stats":{"compute_ops":1,"read_ops":1,"write_ops":2,"query_time_ms":52,"contention_retries":0,"storage_bytes_read":2870,"storage_bytes_write":1099,"rate_limits_hit":[]},"schema_version":1728562581620000}

DEBUG:fauna:query.request method=POST url=http://localhost:8443/query/1 headers=Headers({'host': 'localhost:8443', 'accept': '*/*', 'connection': 'keep-alive', 'user-agent': 'python-httpx/0.27.0', 'accept-encoding': 'gzip', 'content-type': 'application/json;charset=utf-8', 'x-driver': 'python', 'x-driver-env': 'driver=python-2.2.0; runtime=python-3.11.7-final env=unknown; os=darwin-23.6.0', 'x-format': 'tagged', 'x-query-timeout-ms': '5000', 'x-last-txn-ts': '1728562773960000', 'content-length': '76'}) data={'query': {'fql': ["Collection.create({name:'Product'})"]}, 'arguments': {}}

DEBUG:fauna:query.response status_code=200 headers=Headers({'x-faunadb-build': '24.09.04-1d6ea0d', 'connection': 'keep-alive', 'traceparent': '00-4408756b7a30e8ef30de8129bd743573-2c94a65e80d073e2-00', 'content-length': '407', 'content-type': 'application/json;charset=utf-8'}) data={"data":{"@doc":{"name":"Product","coll":{"@mod":"Collection"},"ts":{"@time":"2024-10-10T12:19:34.030Z"},"indexes":{},"constraints":[],"history_days":{"@int":"0"}}},"summary":"","txn_ts":1728562774030000,"stats":{"compute_ops":1,"read_ops":0,"write_ops":2,"query_time_ms":66,"contention_retries":1,"storage_bytes_read":4452,"storage_bytes_write":1089,"rate_limits_hit":[]},"schema_version":1728562773960000}

DEBUG:fauna:query.request method=POST url=http://localhost:8443/query/1 headers=Headers({'host': 'localhost:8443', 'accept': '*/*', 'connection': 'keep-alive', 'user-agent': 'python-httpx/0.27.0', 'accept-encoding': 'gzip', 'content-type': 'application/json;charset=utf-8', 'x-driver': 'python', 'x-driver-env': 'driver=python-2.2.0; runtime=python-3.11.7-final env=unknown; os=darwin-23.6.0', 'x-format': 'tagged', 'x-query-timeout-ms': '5000', 'x-last-txn-ts': '1728562774030000', 'content-length': '65'}) data={'query': {'fql': ['Product.all().toStream()']}, 'arguments': {}}

DEBUG:fauna:query.response status_code=200 headers=Headers({'x-faunadb-build': '24.09.04-1d6ea0d', 'connection': 'keep-alive', 'traceparent': '00-a17d66773d3a8d2b2a1a49ef497ae9db-6b831e8dd7e423c1-00', 'content-length': '455', 'content-type': 'application/json;charset=utf-8'}) data={"data":{"@stream":"g9WD1YPGgmdQcm9kdWN0gwAAZipudWxsKoHKhoMAAGYqbnVsbCqCY2FsbIMAAGYqbnVsbCqA9PaDAABmKm51bGwqgwAAZipudWxsKoHKhoMAAGYqbnVsbCqCaHRvU3RyZWFtgwAAZipudWxsKoD09oMAAGYqbnVsbCqDAABmKm51bGwqgILBghpnB8ZWGgNHO8AA"},"summary":"","txn_ts":1728562774055000,"stats":{"compute_ops":1,"read_ops":0,"write_ops":0,"query_time_ms":17,"contention_retries":1,"storage_bytes_read":0,"storage_bytes_write":0,"rate_limits_hit":[]},"schema_version":1728562774030000}

DEBUG:fauna:stream.request method=POST url=http://localhost:8443/stream/1 headers=Headers({'host': 'localhost:8443', 'accept': '*/*', 'connection': 'keep-alive', 'user-agent': 'python-httpx/0.27.0', 'accept-encoding': 'gzip', 'content-type': 'application/json;charset=utf-8', 'x-driver': 'python', 'x-driver-env': 'driver=python-2.2.0; runtime=python-3.11.7-final env=unknown; os=darwin-23.6.0', 'x-format': 'tagged', 'content-length': '209'}) data={'token': 'g9WD1YPGgmdQcm9kdWN0gwAAZipudWxsKoHKhoMAAGYqbnVsbCqCY2FsbIMAAGYqbnVsbCqA9PaDAABmKm51bGwqgwAAZipudWxsKoHKhoMAAGYqbnVsbCqCaHRvU3RyZWFtgwAAZipudWxsKoD09oMAAGYqbnVsbCqDAABmKm51bGwqgILBghpnB8ZWGgNHO8AA'}

DEBUG:fauna:stream.data data={'type': 'status', 'txn_ts': 1728562774055000, 'cursor': 'gsGCGmcHxlYaA0c7wAA=', 'stats': {'read_ops': 8, 'storage_bytes_read': 144, 'compute_ops': 1, 'processing_time_ms': 1, 'rate_limits_hit': []}}

DEBUG:fauna:stream.data data={'type': 'add', 'data': {'@doc': {'id': '411360488987820544', 'coll': {'@mod': 'Product'}, 'ts': {'@time': '2024-10-10T12:19:43.140Z'}}}, 'txn_ts': 1728562783140000, 'cursor': 'gsGCGmcHxl8aCFg7AAA=', 'stats': {'read_ops': 1, 'storage_bytes_read': 51, 'compute_ops': 1, 'processing_time_ms': 5, 'rate_limits_hit': []}}

DEBUG:fauna:stream.data data={'type': 'add', 'data': {'@doc': {'id': '411360490832265728', 'coll': {'@mod': 'Product'}, 'ts': {'@time': '2024-10-10T12:19:44.890Z'}}}, 'txn_ts': 1728562784890000, 'cursor': 'gsGCGmcHxmAaNQxSgAA=', 'stats': {'read_ops': 1, 'storage_bytes_read': 51, 'compute_ops': 1, 'processing_time_ms': 12, 'rate_limits_hit': []}}

```

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [X] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [X] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


