### PR TITLE
[FE-5985] Error when configuring start_ts and cursor at the same time

### DIFF
--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -555,6 +555,10 @@ class StreamIterator:
     self.last_cursor = None
     self._ctx = self._create_stream()
 
+    if opts.start_ts is not None and opts.cursor is not None:
+      err_msg = "Only one of 'start_ts' or 'cursor' can be defined in the StreamOptions."
+      raise TypeError(err_msg)
+
   def __enter__(self):
     return self
 
@@ -670,6 +674,10 @@ class ChangeFeedIterator:
     self._max_backoff = opts.max_backoff or max_backoff
     self._request: Dict[str, Any] = {"token": token.token}
     self._is_done = False
+
+    if opts.start_ts is not None and opts.cursor is not None:
+      err_msg = "Only one of 'start_ts' or 'cursor' can be defined in the ChangeFeedOptions."
+      raise TypeError(err_msg)
 
     if opts.page_size is not None:
       self._request["page_size"] = opts.page_size

--- a/tests/integration/test_change_feeds.py
+++ b/tests/integration/test_change_feeds.py
@@ -114,6 +114,7 @@ def test_change_feed_cursor(client, a_collection):
   nums = [event['data'] for event in feed.flatten()]
   assert nums == list(range(1, 64))
 
+
 def test_rejects_when_both_start_ts_and_cursor_provided(scoped_client):
   scoped_client.query(fql("Collection.create({name: 'Product'})"))
 
@@ -123,6 +124,7 @@ def test_rejects_when_both_start_ts_and_cursor_provided(scoped_client):
   with pytest.raises(TypeError):
     opts = ChangeFeedOptions(cursor="abc1234==", start_ts=response.txn_ts)
     scoped_client.change_feed(stream_token, opts)
+
 
 def test_change_feed_reusable_iterator(client, a_collection):
   feed = client.change_feed(

--- a/tests/integration/test_change_feeds.py
+++ b/tests/integration/test_change_feeds.py
@@ -114,6 +114,15 @@ def test_change_feed_cursor(client, a_collection):
   nums = [event['data'] for event in feed.flatten()]
   assert nums == list(range(1, 64))
 
+def test_rejects_when_both_start_ts_and_cursor_provided(scoped_client):
+  scoped_client.query(fql("Collection.create({name: 'Product'})"))
+
+  response = scoped_client.query(fql("Product.all().toStream()"))
+  stream_token = response.data
+
+  with pytest.raises(TypeError):
+    opts = ChangeFeedOptions(cursor="abc1234==", start_ts=response.txn_ts)
+    scoped_client.change_feed(stream_token, opts)
 
 def test_change_feed_reusable_iterator(client, a_collection):
   feed = client.change_feed(

--- a/tests/integration/test_stream.py
+++ b/tests/integration/test_stream.py
@@ -228,6 +228,7 @@ def test_rejects_cursor_with_fql_query(scoped_client):
     opts = StreamOptions(cursor="abc1234==")
     scoped_client.stream(fql("Collection.create({name: 'Product'})"), opts)
 
+
 def test_rejects_when_both_start_ts_and_cursor_provided(scoped_client):
   scoped_client.query(fql("Collection.create({name: 'Product'})"))
 
@@ -237,6 +238,7 @@ def test_rejects_when_both_start_ts_and_cursor_provided(scoped_client):
   with pytest.raises(TypeError):
     opts = StreamOptions(cursor="abc1234==", start_ts=response.txn_ts)
     scoped_client.stream(stream_token, opts)
+
 
 def test_handle_status_events(scoped_client):
   scoped_client.query(fql("Collection.create({name: 'Product'})"))

--- a/tests/integration/test_stream.py
+++ b/tests/integration/test_stream.py
@@ -228,6 +228,15 @@ def test_rejects_cursor_with_fql_query(scoped_client):
     opts = StreamOptions(cursor="abc1234==")
     scoped_client.stream(fql("Collection.create({name: 'Product'})"), opts)
 
+def test_rejects_when_both_start_ts_and_cursor_provided(scoped_client):
+  scoped_client.query(fql("Collection.create({name: 'Product'})"))
+
+  response = scoped_client.query(fql("Product.all().toStream()"))
+  stream_token = response.data
+
+  with pytest.raises(TypeError):
+    opts = StreamOptions(cursor="abc1234==", start_ts=response.txn_ts)
+    scoped_client.stream(stream_token, opts)
 
 def test_handle_status_events(scoped_client):
   scoped_client.query(fql("Collection.create({name: 'Product'})"))


### PR DESCRIPTION
[FE-5985](https://faunadb.atlassian.net/browse/FE-5985)

### Description
Added additional input validation for `StreamIterator` and `ChangeFeedIterator` constructors: raise an error if both `cursor` and `start_ts` are provided as options.

### Motivation and context
We currently allow both start_ts and cursor options to be provided at the same time for Streams and ChangeFeeds. When that happens, `cursor` is used and `start_ts` is silently ignored. We should raise an error instead.

This is a follow up to a previous discussion: https://github.com/fauna/fauna-python/pull/192#discussion_r1766983360

### How was the change tested?
Additional integration tests were added to confirm an error is raised.

### Screenshots (if appropriate):

### Change types
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [x] Breaking change (backwards-incompatible fix or feature)
    * The `cursor` option is part of the beta release of change feeds, so while technically breaking, it only breaks the experimental/beta features that have been released.

### Checklist:
* - [ ] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.




[FE-5985]: https://faunadb.atlassian.net/browse/FE-5985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ