### PR TITLE
docs: [DOCS-3549] Rename Change Feeds to Event Feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,165 @@ for products in pages:
         print(products)
 ```
 
+## Event Feeds (beta)
+
+The driver supports [Event Feeds](https://docs.fauna.com/fauna/current/learn/track-changes/streaming/#event-feeds).
+
+### Request an Event Feed
+
+An Event Feed asynchronously polls an [event stream](https://docs.fauna.com/fauna/current/learn/streaming),
+represented by a stream token, for events.
+
+To get a stream token, append ``toStream()`` or ``changesOn()`` to a set from a
+[supported source](https://docs.fauna.com/fauna/current/reference/streaming_reference/#supported-sources).
+
+To get paginated events for the stream, pass the stream token to
+``change_feed()``:
+
+```python
+  from fauna import fql
+  from fauna.client import Client
+
+  client = Client()
+
+  response = client.query(fql('''
+  let set = Product.all()
+  {
+    initialPage: set.pageSize(10),
+    streamToken: set.toStream()
+  }
+  '''))
+
+  initialPage = response.data['initialPage']
+  streamToken = response.data['streamToken']
+
+  client.change_feed(streamToken)
+```
+
+You can also pass a query that produces a stream token directly to
+``change_feed()``:
+
+```python
+  query = fql('Product.all().changesOn(.price, .stock)')
+
+  client.change_feed(query)
+```
+
+### Iterate on an Event Feed
+
+``change_feed()`` returns an iterator that emits pages of events. You can use a
+generator expression to iterate through the pages:
+
+```python
+  query = fql('Product.all().changesOn(.price, .stock)')
+  feed = client.change_feed(query)
+
+  for page in feed:
+    print('Page stats: ', page.stats)
+
+    for event in page:
+      eventType = event['type']
+      if (eventType == 'add'):
+        print('Add event: ', event)
+        ## ...
+      elif (eventType == 'update'):
+        print('Update event: ', event)
+        ## ...
+      elif (eventType == 'remove'):
+        print('Remove event: ', event)
+        ## ...
+```
+
+Alternatively, you can iterate through events instead of pages with
+``flatten()``:
+
+```python
+  query = fql('Product.all().changesOn(.price, .stock)')
+  feed = client.change_feed(query)
+
+  for event in feed.flatten():
+    eventType = event['type']
+    ## ...
+```
+
+The Event Feed iterator stops when there are no more events to poll.
+
+### Error handling
+
+If a non-retryable error occurs when opening or processing an Event Feed, Fauna
+raises a ``FaunaException``:
+
+```python
+  from fauna import fql
+  from fauna.client import Client
+  from fauna.errors import FaunaException
+
+  client = Client()
+
+  try:
+    feed = client.change_feed(fql(
+      'Product.all().changesOn(.price, .stock)'
+    ))
+    for event in feed.flatten():
+      print(event)
+      # ...
+  except FaunaException as e:
+    print('error ocurred with event feed: ', e)
+```
+
+Errors can be raised at two different places:
+
+1. At the ``change_feed`` method call;
+2. At the page iteration.
+
+This distinction allows for users to ignore errors originating from event
+processing. For example:
+
+```python
+  from fauna import fql
+  from fauna.client import Client
+  from fauna.errors import FaunaException
+
+  client = Client()
+
+  # Imagine if there are some products with details = null.
+  # The ones without details will fail due to the toUpperCase call.
+  feed = client.change_feed(fql(
+    'Product.all().map(.details.toUpperCase()).toStream()'
+  ))
+
+  for page in feed:
+    try:
+      for event in page:
+        print(event)
+        # ...
+    except FaunaException as e:
+      # Pages will stop at the first error encountered.
+      # Therefore, its safe to handle an event failures
+      # and then pull more pages.
+      print('error ocurred with event processing: ', e)
+```
+
+### Event Feed options
+
+The client configuration sets default options for the ``change_feed()``
+method.
+
+You can pass a ``ChangeFeedOptions`` object to override these defaults:
+
+```python
+options = ChangeFeedOptions(
+  max_attempts=3,
+  max_backoff=20,
+  query_timeout=timedelta(seconds=5),
+  page_size=None,
+  cursor=None,
+  start_ts=None,
+ )
+
+client.change_feed(fql('Product.all().toStream()'), options)
+```
+
 ## Event Streaming
 
 The driver supports [Event Streaming](https://docs.fauna.com/fauna/current/learn/streaming).
@@ -407,165 +566,6 @@ options = StreamOptions(
  )
 
 client.stream(fql('Product.all().toStream()'), options)
-```
-
-## Change Feeds (beta)
-
-The driver supports [Change Feeds](https://docs.fauna.com/fauna/current/learn/track-changes/streaming/#change-feeds).
-
-### Request a Change Feed
-
-A Change Feed asynchronously polls an [event stream](https://docs.fauna.com/fauna/current/learn/streaming),
-represented by a stream token, for events. 
-
-To get a stream token, append ``toStream()`` or ``changesOn()`` to a set from a
-[supported source](https://docs.fauna.com/fauna/current/reference/streaming_reference/#supported-sources).
-
-To get paginated events for the stream, pass the stream token to
-``change_feed()``:
-
-```python
-  from fauna import fql
-  from fauna.client import Client
-
-  client = Client()
-
-  response = client.query(fql('''
-  let set = Product.all()
-  {
-    initialPage: set.pageSize(10),
-    streamToken: set.toStream()
-  }
-  '''))
-
-  initialPage = response.data['initialPage']
-  streamToken = response.data['streamToken']
-
-  client.change_feed(streamToken)
-```
-
-You can also pass a query that produces a stream token directly to
-``change_feed()``:
-
-```python
-  query = fql('Product.all().changesOn(.price, .stock)')
-
-  client.change_feed(query)
-```
-
-### Iterate on a Change Feed
-
-``change_feed()`` returns an iterator that emits pages of events. You can use a
-generator expression to iterate through the pages:
-
-```python
-  query = fql('Product.all().changesOn(.price, .stock)')
-  feed = client.change_feed(query)
-
-  for page in feed:
-    print('Page stats: ', page.stats)
-  
-    for event in page:
-      eventType = event['type']
-      if (eventType == 'add'):
-        print('Add event: ', event)
-        ## ...
-      elif (eventType == 'update'):
-        print('Update event: ', event)
-        ## ...
-      elif (eventType == 'remove'):
-        print('Remove event: ', event)
-        ## ...
-```
-
-Alternatively, you can iterate through events instead of pages with
-``flatten()``:
-
-```python
-  query = fql('Product.all().changesOn(.price, .stock)')
-  feed = client.change_feed(query)
-
-  for event in feed.flatten():
-    eventType = event['type']
-    ## ...
-```
-
-The change feed iterator stops when there are no more events to poll.
-
-### Error handling
-
-If a non-retryable error occurs when opening or processing a change feed, Fauna
-raises a ``FaunaException``:
-
-```python
-  from fauna import fql
-  from fauna.client import Client
-  from fauna.errors import FaunaException
-  
-  client = Client()
-  
-  try:
-    feed = client.change_feed(fql(
-      'Product.all().changesOn(.price, .stock)'
-    ))
-    for event in feed.flatten():
-      print(event)
-      # ...
-  except FaunaException as e:
-    print('error ocurred with change feed: ', e)
-```
-
-Errors can be raised at two different places:
-
-1. At the ``change_feed`` method call;
-2. At the page iteration.
-
-This distinction allows for users to ignore errors originating from event
-processing. For example:
-
-```python
-  from fauna import fql
-  from fauna.client import Client
-  from fauna.errors import FaunaException
-  
-  client = Client()
-  
-  # Imagine if there are some products with details = null.
-  # The ones without details will fail due to the toUpperCase call.
-  feed = client.change_feed(fql(
-    'Product.all().map(.details.toUpperCase()).toStream()'
-  ))
-  
-  for page in feed:
-    try:
-      for event in page:
-        print(event)
-        # ...
-    except FaunaException as e:
-      # Pages will stop at the first error encountered.
-      # Therefore, its safe to handle an event failures
-      # and then pull more pages.
-      print('error ocurred with event processing: ', e)
-```
-
-### Change Feed options
-
-The client configuration sets default options for the ``change_feed()``
-method.
-
-You can pass a ``ChangeFeedOptions`` object to override these defaults:
-
-```python
-options = ChangeFeedOptions(
-  max_attempts=3,
-  max_backoff=20,
-  query_timeout=timedelta(seconds=5),
-  page_size=None,
-  cursor=None,
-  start_ts=None,
- )
-
-client.change_feed(fql('Product.all().toStream()'), options)
 ```
 
 ## Setup

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -73,12 +73,12 @@ class StreamOptions:
 @dataclass
 class ChangeFeedOptions:
   """
-    A dataclass representing options available for a change feed.
+    A dataclass representing options available for an Event Feed.
 
-    * max_attempts - The maximum number of times to attempt a change feed query when a retryable exception is thrown.
+    * max_attempts - The maximum number of times to attempt an Event Feed query when a retryable exception is thrown.
     * max_backoff - The maximum backoff in seconds for an individual retry.
     * query_timeout - Controls the maximum amount of time Fauna will execute a query before returning a page of events.
-    * start_ts - The starting timestamp of the change feed, exclusive. If set, Fauna will return events starting after
+    * start_ts - The starting timestamp of the Event Feed, exclusive. If set, Fauna will return events starting after
     the timestamp.
     * cursor - The starting event cursor, exclusive. If set, Fauna will return events starting after the cursor.
     * page_size - The desired number of events per page.
@@ -465,10 +465,10 @@ class Client:
       opts: ChangeFeedOptions = ChangeFeedOptions()
   ) -> "ChangeFeedIterator":
     """
-        Opens a change feed in Fauna and returns an iterator that consume Fauna events.
+        Opens an Event Feed in Fauna and returns an iterator that consume Fauna events.
 
         :param fql: A Query that returns a StreamToken or a StreamToken.
-        :param opts: (Optional) Change feed options.
+        :param opts: (Optional) Event Feed options.
 
         :return: a :class:`ChangeFeedIterator`
 
@@ -658,7 +658,7 @@ class ChangeFeedPage:
 
 
 class ChangeFeedIterator:
-  """A class to provide an iterator on top of change feed pages."""
+  """A class to provide an iterator on top of Event Feed pages."""
 
   def __init__(self, http: HTTPClient, headers: Dict[str, str], endpoint: str,
                max_attempts: int, max_backoff: int, opts: ChangeFeedOptions,


### PR DESCRIPTION
Renames `Changed Feeds` to `Event Feeds` in the README and comments.

### Description
* Renames `Changed Feeds` to `Event Feeds` in the README and comments.
* Move the `Change Feeds` section before the `Event Streaming` section in the README (per Product request)

I'll merge this PR at the same time as documentation changes go live.

### Motivation and context
Align with our documentation and marketing

### How was the change tested?
N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


