### PR TITLE
Rename CDC terms

### DIFF
--- a/fauna/client/__init__.py
+++ b/fauna/client/__init__.py
@@ -1,3 +1,3 @@
-from .client import Client, QueryOptions, StreamOptions, ChangeFeedOptions
+from .client import Client, QueryOptions, StreamOptions, FeedOptions, FeedPage, FeedIterator
 from .endpoints import Endpoints
 from .headers import Header

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -70,7 +70,7 @@ class StreamOptions:
 
 
 @dataclass
-class ChangeFeedOptions:
+class FeedOptions:
   """
     A dataclass representing options available for an Event Feed.
 
@@ -425,7 +425,7 @@ class Client:
     """
         Opens a Stream in Fauna and returns an iterator that consume Fauna events.
 
-        :param fql: A Query that returns a EventSource or a EventSource.
+        :param fql: An EventSource or a Query that returns an EventSource.
         :param opts: (Optional) Stream Options.
 
         :return: a :class:`StreamIterator`
@@ -443,12 +443,12 @@ class Client:
         raise ClientError(
             "The 'cursor' configuration can only be used with an event source.")
 
-      token = self.query(fql).data
+      source = self.query(fql).data
     else:
-      token = fql
+      source = fql
 
-    if not isinstance(token, EventSource):
-      err_msg = f"'fql' must be a EventSource, or a Query that returns a EventSource but was a {type(token)}."
+    if not isinstance(source, EventSource):
+      err_msg = f"'fql' must be an EventSource, or a Query that returns an EventSource but was a {type(source)}."
       raise TypeError(err_msg)
 
     headers = self._headers.copy()
@@ -456,20 +456,20 @@ class Client:
     headers[_Header.Authorization] = self._auth.bearer()
 
     return StreamIterator(self._session, headers, self._endpoint + "/stream/1",
-                          self._max_attempts, self._max_backoff, opts, token)
+                          self._max_attempts, self._max_backoff, opts, source)
 
-  def change_feed(
+  def feed(
       self,
-      fql: Union[EventSource, Query],
-      opts: ChangeFeedOptions = ChangeFeedOptions()
-  ) -> "ChangeFeedIterator":
+      source: Union[EventSource, Query],
+      opts: FeedOptions = FeedOptions(),
+  ) -> "FeedIterator":
     """
         Opens an Event Feed in Fauna and returns an iterator that consume Fauna events.
 
-        :param fql: A Query that returns a EventSource or a EventSource.
+        :param source: An EventSource or a Query that returns an EventSource.
         :param opts: (Optional) Event Feed options.
 
-        :return: a :class:`ChangeFeedIterator`
+        :return: a :class:`FeedIterator`
 
         :raises ClientError: Invalid options provided
         :raises NetworkError: HTTP Request failed in transit
@@ -479,13 +479,11 @@ class Client:
         :raises TypeError: Invalid param types
         """
 
-    if isinstance(fql, Query):
-      token = self.query(fql).data
-    else:
-      token = fql
+    if isinstance(source, Query):
+      source = self.query(source).data
 
-    if not isinstance(token, EventSource):
-      err_msg = f"'fql' must be a EventSource, or a Query that returns a EventSource but was a {type(token)}."
+    if not isinstance(source, EventSource):
+      err_msg = f"'source' must be an EventSource, or a Query that returns an EventSource but was a {type(source)}."
       raise TypeError(err_msg)
 
     headers = self._headers.copy()
@@ -498,10 +496,8 @@ class Client:
     elif self._query_timeout_ms is not None:
       headers[Header.QueryTimeoutMs] = str(self._query_timeout_ms)
 
-    return ChangeFeedIterator(self._session, headers,
-                              self._endpoint + "/changefeed/1",
-                              self._max_attempts, self._max_backoff, opts,
-                              token)
+    return FeedIterator(self._session, headers, self._endpoint + "/feed/1",
+                        self._max_attempts, self._max_backoff, opts, source)
 
   def _check_protocol(self, response_json: Any, status_code):
     # TODO: Logic to validate wire protocol belongs elsewhere.
@@ -541,14 +537,14 @@ class StreamIterator:
 
   def __init__(self, http_client: HTTPClient, headers: Dict[str, str],
                endpoint: str, max_attempts: int, max_backoff: int,
-               opts: StreamOptions, token: EventSource):
+               opts: StreamOptions, source: EventSource):
     self._http_client = http_client
     self._headers = headers
     self._endpoint = endpoint
     self._max_attempts = max_attempts
     self._max_backoff = max_backoff
     self._opts = opts
-    self._token = token
+    self._source = source
     self._stream = None
     self.last_ts = None
     self.last_cursor = None
@@ -627,7 +623,7 @@ class StreamIterator:
     raise RetryableFaunaException
 
   def _create_stream(self):
-    data: Dict[str, Any] = {"token": self._token.token}
+    data: Dict[str, Any] = {"token": self._source.token}
     if self.last_cursor is not None:
       data["cursor"] = self.last_cursor
     elif self._opts.cursor is not None:
@@ -643,7 +639,7 @@ class StreamIterator:
       self._stream.close()
 
 
-class ChangeFeedPage:
+class FeedPage:
 
   def __init__(self, events: List[Any], cursor: str, stats: QueryStats):
     self._events = events
@@ -660,22 +656,22 @@ class ChangeFeedPage:
       yield event
 
 
-class ChangeFeedIterator:
+class FeedIterator:
   """A class to provide an iterator on top of Event Feed pages."""
 
   def __init__(self, http: HTTPClient, headers: Dict[str, str], endpoint: str,
-               max_attempts: int, max_backoff: int, opts: ChangeFeedOptions,
-               token: EventSource):
+               max_attempts: int, max_backoff: int, opts: FeedOptions,
+               source: EventSource):
     self._http = http
     self._headers = headers
     self._endpoint = endpoint
     self._max_attempts = opts.max_attempts or max_attempts
     self._max_backoff = opts.max_backoff or max_backoff
-    self._request: Dict[str, Any] = {"token": token.token}
+    self._request: Dict[str, Any] = {"token": source.token}
     self._is_done = False
 
     if opts.start_ts is not None and opts.cursor is not None:
-      err_msg = "Only one of 'start_ts' or 'cursor' can be defined in the ChangeFeedOptions."
+      err_msg = "Only one of 'start_ts' or 'cursor' can be defined in the FeedOptions."
       raise TypeError(err_msg)
 
     if opts.page_size is not None:
@@ -686,11 +682,11 @@ class ChangeFeedIterator:
     elif opts.start_ts is not None:
       self._request["start_ts"] = opts.start_ts
 
-  def __iter__(self) -> Iterator[ChangeFeedPage]:
+  def __iter__(self) -> Iterator[FeedPage]:
     self._is_done = False
     return self
 
-  def __next__(self) -> ChangeFeedPage:
+  def __next__(self) -> FeedPage:
     if self._is_done:
       raise StopIteration
 
@@ -698,7 +694,7 @@ class ChangeFeedIterator:
                                self._next_page)
     return retryable.run().response
 
-  def _next_page(self) -> ChangeFeedPage:
+  def _next_page(self) -> FeedPage:
     with self._http.request(
         method="POST",
         url=self._endpoint,
@@ -717,8 +713,8 @@ class ChangeFeedIterator:
       if "start_ts" in self._request:
         del self._request["start_ts"]
 
-      return ChangeFeedPage(decoded["events"], decoded["cursor"],
-                            QueryStats(decoded["stats"]))
+      return FeedPage(decoded["events"], decoded["cursor"],
+                      QueryStats(decoded["stats"]))
 
   def flatten(self) -> Iterator:
     """A generator that yields events instead of pages of events."""

--- a/fauna/encoding/decoder.py
+++ b/fauna/encoding/decoder.py
@@ -4,7 +4,7 @@ from typing import Any, List, Union
 from iso8601 import parse_date
 
 from fauna.query.models import Module, DocumentReference, Document, NamedDocument, NamedDocumentReference, Page, \
-  NullDocument, StreamToken
+  NullDocument, EventSource
 
 
 class FaunaDecoder:
@@ -45,7 +45,7 @@ class FaunaDecoder:
      +--------------------+---------------+
      | Page               | @set          |
      +--------------------+---------------+
-     | StreamToken        | @stream       |
+     | EventSource        | @stream       |
      +--------------------+---------------+
 
      """
@@ -64,7 +64,7 @@ class FaunaDecoder:
             - { "@ref": ... } decodes to a DocumentReference or NamedDocumentReference
             - { "@mod": ... } decodes to a Module
             - { "@set": ... } decodes to a Page
-            - { "@stream": ... } decodes to a StreamToken
+            - { "@stream": ... } decodes to a EventSource
             - { "@bytes": ... } decodes to a bytearray
 
         :param obj: the object to decode
@@ -176,6 +176,6 @@ class FaunaDecoder:
         return Page(data=data, after=after)
 
       if "@stream" in dct:
-        return StreamToken(dct["@stream"])
+        return EventSource(dct["@stream"])
 
     return {k: FaunaDecoder._decode(v) for k, v in dct.items()}

--- a/fauna/encoding/decoder.py
+++ b/fauna/encoding/decoder.py
@@ -64,7 +64,7 @@ class FaunaDecoder:
             - { "@ref": ... } decodes to a DocumentReference or NamedDocumentReference
             - { "@mod": ... } decodes to a Module
             - { "@set": ... } decodes to a Page
-            - { "@stream": ... } decodes to a EventSource
+            - { "@stream": ... } decodes to an EventSource
             - { "@bytes": ... } decodes to a bytearray
 
         :param obj: the object to decode

--- a/fauna/encoding/encoder.py
+++ b/fauna/encoding/encoder.py
@@ -3,7 +3,7 @@ from datetime import datetime, date
 from typing import Any, Optional, List, Union
 
 from fauna.query.models import DocumentReference, Module, Document, NamedDocument, NamedDocumentReference, NullDocument, \
-  StreamToken
+  EventSource
 from fauna.query.query_builder import Query, Fragment, LiteralFragment, ValueFragment
 
 _RESERVED_TAGS = [
@@ -62,7 +62,7 @@ class FaunaEncoder:
     +-------------------------------+---------------+
     | TemplateFragment              | string        |
     +-------------------------------+---------------+
-    | StreamToken                   | string        |
+    | EventSource                   | string        |
     +-------------------------------+---------------+
 
     """
@@ -82,7 +82,7 @@ class FaunaEncoder:
             - Query encodes to { "fql": [...] }
             - ValueFragment encodes to { "value": <encoded_val> }
             - LiteralFragment encodes to a string
-            - StreamToken encodes to a string
+            - EventSource encodes to a string
 
         :raises ValueError: If value cannot be encoded, cannot be encoded safely, or there's a circular reference.
         :param obj: the object to decode
@@ -163,7 +163,7 @@ class FaunaEncoder:
     return {"fql": [FaunaEncoder.from_fragment(f) for f in obj.fragments]}
 
   @staticmethod
-  def from_streamtoken(obj: StreamToken):
+  def from_streamtoken(obj: EventSource):
     return {"@stream": obj.token}
 
   @staticmethod
@@ -208,7 +208,7 @@ class FaunaEncoder:
       return FaunaEncoder._encode_dict(o, _markers)
     elif isinstance(o, Query):
       return FaunaEncoder.from_query_interpolation_builder(o)
-    elif isinstance(o, StreamToken):
+    elif isinstance(o, EventSource):
       return FaunaEncoder.from_streamtoken(o)
     else:
       raise ValueError(f"Object {o} of type {type(o)} cannot be encoded")

--- a/fauna/query/__init__.py
+++ b/fauna/query/__init__.py
@@ -1,2 +1,2 @@
-from .models import Document, DocumentReference, NamedDocument, NamedDocumentReference, NullDocument, Module, Page
+from .models import Document, DocumentReference, EventSource, NamedDocument, NamedDocumentReference, NullDocument, Module, Page
 from .query_builder import fql, Query

--- a/fauna/query/models.py
+++ b/fauna/query/models.py
@@ -13,11 +13,11 @@ def __getattr__(name):
         DeprecationWarning,
         stacklevel=2)
     return EventSource
-  return super.__getattr__(name)
+  return super.__getattr__(name)  # pyright: ignore
 
 
 def __dir__():
-  return super.__dir__() + "StreamToken"
+  return super.__dir__() + "StreamToken"  # pyright: ignore
 
 
 class Page:

--- a/fauna/query/models.py
+++ b/fauna/query/models.py
@@ -1,6 +1,23 @@
+import warnings
 from collections.abc import Mapping
 from datetime import datetime
 from typing import Union, Iterator, Any, Optional, List
+
+
+# NB. Override __getattr__ and __dir__ to deprecate StreamToken usages. Based
+# on: https://peps.python.org/pep-0562/
+def __getattr__(name):
+  if name == "StreamToken":
+    warnings.warn(
+        "StreamToken is deprecated. Prefer fauna.query.EventSource instead.",
+        DeprecationWarning,
+        stacklevel=2)
+    return EventSource
+  return super.__getattr__(name)
+
+
+def __dir__():
+  return super.__dir__() + "StreamToken"
 
 
 class Page:
@@ -36,14 +53,14 @@ class Page:
     return not self.__eq__(other)
 
 
-class StreamToken:
-  """A class represeting a Stream in Fauna."""
+class EventSource:
+  """A class represeting an EventSource in Fauna."""
 
   def __init__(self, token: str):
     self.token = token
 
   def __eq__(self, other):
-    return isinstance(other, StreamToken) and self.token == other.token
+    return isinstance(other, EventSource) and self.token == other.token
 
   def __hash__(self):
     return hash(self.token)

--- a/tests/integration/test_stream.py
+++ b/tests/integration/test_stream.py
@@ -167,7 +167,7 @@ def test_last_ts_is_monotonic(scoped_client):
 def test_providing_start_ts(scoped_client):
   scoped_client.query(fql("Collection.create({name: 'Product'})"))
 
-  stream_token = scoped_client.query(fql("Product.all().toStream()")).data
+  source = scoped_client.query(fql("Product.all().toStream()")).data
 
   createOne = scoped_client.query(fql("Product.create({})"))
   createTwo = scoped_client.query(fql("Product.create({})"))
@@ -178,7 +178,7 @@ def test_providing_start_ts(scoped_client):
 
   def thread_fn():
     # replay excludes the ts that was passed in, it provides events for all ts after the one provided
-    stream = scoped_client.stream(stream_token,
+    stream = scoped_client.stream(source,
                                   StreamOptions(start_ts=createOne.txn_ts))
     barrier.wait()
     with stream as iter:
@@ -201,12 +201,12 @@ def test_providing_start_ts(scoped_client):
 def test_providing_cursor(scoped_client):
   scoped_client.query(fql("Collection.create({name: 'Product'})"))
 
-  stream_token = scoped_client.query(fql("Product.all().toStream()")).data
+  source = scoped_client.query(fql("Product.all().toStream()")).data
   create1 = scoped_client.query(fql("Product.create({ value: 1 })"))
   create2 = scoped_client.query(fql("Product.create({ value: 2 })"))
 
   cursor = None
-  with scoped_client.stream(stream_token) as iter:
+  with scoped_client.stream(source) as iter:
     for event in iter:
       assert event["type"] == "add"
       assert event["data"]["value"] == 1
@@ -214,7 +214,7 @@ def test_providing_cursor(scoped_client):
       break
 
   opts = StreamOptions(cursor=cursor)
-  with scoped_client.stream(stream_token, opts) as iter:
+  with scoped_client.stream(source, opts) as iter:
     for event in iter:
       assert event["type"] == "add"
       assert event["data"]["value"] == 2
@@ -224,7 +224,8 @@ def test_providing_cursor(scoped_client):
 def test_rejects_cursor_with_fql_query(scoped_client):
   with pytest.raises(
       ClientError,
-      match="The 'cursor' configuration can only be used with a stream token."):
+      match="The 'cursor' configuration can only be used with an event source."
+  ):
     opts = StreamOptions(cursor="abc1234==")
     scoped_client.stream(fql("Collection.create({name: 'Product'})"), opts)
 
@@ -233,11 +234,11 @@ def test_rejects_when_both_start_ts_and_cursor_provided(scoped_client):
   scoped_client.query(fql("Collection.create({name: 'Product'})"))
 
   response = scoped_client.query(fql("Product.all().toStream()"))
-  stream_token = response.data
+  source = response.data
 
   with pytest.raises(TypeError):
     opts = StreamOptions(cursor="abc1234==", start_ts=response.txn_ts)
-    scoped_client.stream(stream_token, opts)
+    scoped_client.stream(source, opts)
 
 
 def test_handle_status_events(scoped_client):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -11,7 +11,7 @@ from fauna import fql
 from fauna.client import Client, Header, QueryOptions, Endpoints, StreamOptions
 from fauna.errors import QueryCheckError, ProtocolError, QueryRuntimeError, NetworkError, AbortError
 from fauna.http import HTTPXClient
-from fauna.query.models import StreamToken
+from fauna.query import EventSource
 
 
 def test_client_defaults(monkeypatch):
@@ -429,7 +429,7 @@ def test_client_stream(subtests, httpx_mock: HTTPXMock):
   with httpx.Client() as mockClient:
     http_client = HTTPXClient(mockClient)
     c = Client(http_client=http_client)
-    with c.stream(StreamToken("token")) as stream:
+    with c.stream(EventSource("token")) as stream:
       ret = [obj for obj in stream]
 
       assert stream.last_ts == 3
@@ -456,7 +456,7 @@ def test_client_close_stream(subtests, httpx_mock: HTTPXMock):
   with httpx.Client() as mockClient:
     http_client = HTTPXClient(mockClient)
     c = Client(http_client=http_client)
-    with c.stream(StreamToken("token")) as stream:
+    with c.stream(EventSource("token")) as stream:
       assert next(stream) == {"type": "add", "txn_ts": 2, "cursor": "b"}
       stream.close()
 
@@ -484,7 +484,7 @@ def test_client_retry_stream(subtests, httpx_mock: HTTPXMock):
   with httpx.Client() as mockClient:
     http_client = HTTPXClient(mockClient)
     c = Client(http_client=http_client)
-    with c.stream(StreamToken("token")) as stream:
+    with c.stream(EventSource("token")) as stream:
       ret = [obj for obj in stream]
 
       assert stream.last_ts == 4
@@ -508,7 +508,7 @@ def test_client_close_stream_on_error(subtests, httpx_mock: HTTPXMock):
     with httpx.Client() as mockClient:
       http_client = HTTPXClient(mockClient)
       c = Client(http_client=http_client)
-      with c.stream(StreamToken("token")) as stream:
+      with c.stream(EventSource("token")) as stream:
         for obj in stream:
           ret.append(obj)
 
@@ -533,7 +533,7 @@ def test_client_ignore_start_event(subtests, httpx_mock: HTTPXMock):
   with httpx.Client() as mockClient:
     http_client = HTTPXClient(mockClient)
     c = Client(http_client=http_client)
-    with c.stream(StreamToken("token")) as stream:
+    with c.stream(EventSource("token")) as stream:
       for obj in stream:
         ret.append(obj)
 
@@ -565,7 +565,7 @@ def test_client_handle_status_events(subtests, httpx_mock: HTTPXMock):
   with httpx.Client() as mockClient:
     http_client = HTTPXClient(mockClient)
     c = Client(http_client=http_client)
-    with c.stream(StreamToken("token"),
+    with c.stream(EventSource("token"),
                   StreamOptions(status_events=True)) as stream:
       for obj in stream:
         ret.append(obj)

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -8,7 +8,7 @@ import pytest
 from fauna import fql
 from fauna.encoding import FaunaEncoder, FaunaDecoder
 from fauna.query.models import DocumentReference, NamedDocumentReference, Document, NamedDocument, Module, Page, \
-  NullDocument, StreamToken
+  NullDocument, EventSource
 
 fixed_datetime = datetime.fromisoformat("2023-03-17T00:00:00+00:00")
 
@@ -799,14 +799,14 @@ def test_encode_query_builder_sub_queries(subtests):
 
 
 def test_decode_stream(subtests):
-  with subtests.test(msg="decode @stream into StreamToken"):
+  with subtests.test(msg="decode @stream into EventSource"):
     test = {"@stream": "asdflkj"}
     decoded = FaunaDecoder.decode(test)
-    assert decoded == StreamToken("asdflkj")
+    assert decoded == EventSource("asdflkj")
 
 
 def test_encode_stream(subtests):
-  with subtests.test(msg="encode StreamToken into @stream"):
+  with subtests.test(msg="encode EventSource into @stream"):
     test = {"@stream": "asdflkj"}
-    encoded = FaunaEncoder.encode(StreamToken("asdflkj"))
+    encoded = FaunaEncoder.encode(EventSource("asdflkj"))
     assert encoded == test

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,4 +1,5 @@
 import datetime
+import pytest
 
 from fauna.query.models import Document, Module, NamedDocument, BaseReference, DocumentReference, \
   NamedDocumentReference, Page
@@ -131,3 +132,9 @@ def test_document_equality(subtests):
     other = 123
     _ = d1 == other
     _ = d1 != other
+
+
+def test_stream_token_deprecation():
+  with pytest.deprecated_call():
+    from fauna.query.models import StreamToken, EventSource
+    assert StreamToken == EventSource  # same runtime.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description

This patch renames CDC terms according to our new guidelines.

### Motivation and context

* "Steam token" becomes "Event source"
* `.change_feed(..)` becomes `.feed(..)`
* `ChangeFeed{Options,Iterator,Page}` becomes `Feed{Options,Iterator,Page}`

Old terms related to streaming are deprecated and should be removed in the next major version. Old terms related to event feeds were ripped off.

### How was the change tested?

Unit tests included.

### Screenshots (if appropriate):

NA.

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [X] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [X] My change requires a change to Fauna documentation.
* - [X] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


