### PR TITLE
docs: Update CDC links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,17 +287,17 @@ for products in pages:
 
 ## Event Feeds (beta)
 
-The driver supports [Event Feeds](https://docs.fauna.com/fauna/current/learn/track-changes/streaming/#event-feeds).
+The driver supports [Event Feeds](https://docs.fauna.com/fauna/current/learn/cdc/#event-feeds).
 
 ### Request an Event Feed
 
-An Event Feed asynchronously polls an [event source](https://docs.fauna.com/fauna/current/learn/streaming),
+An Event Feed asynchronously polls an [event source](https://docs.fauna.com/fauna/current/learn/cdc/#create-an-event-source)
 for paginated events.
 
 To get an event source, append ``eventSource()`` or ``eventsOn()`` to a
-[supported Set](https://docs.fauna.com/fauna/current/reference/streaming_reference/#sets). 
+[supported Set](https://docs.fauna.com/fauna/current/reference/cdc/#sets).
 
-To get paginated events for the source, pass the event source to ``feed()``:
+To get paginated events, pass the event source to ``feed()``:
 
 ```python
   from fauna import fql
@@ -443,12 +443,17 @@ client.feed(fql('Product.all().eventSource()'), options)
 
 ## Event Streaming
 
-The driver supports [Event Streaming](https://docs.fauna.com/fauna/current/learn/streaming).
+The driver supports [Event
+Streaming](https://docs.fauna.com/fauna/current/reference/cdc/#event-streaming).
 
 ### Start a stream
 
+An Event Stream lets you consume events from an [event
+source](https://docs.fauna.com/fauna/current/learn/cdc/#create-an-event-source)
+as a real-time subscription.
+
 To get an event source, append ``eventSource()`` or ``eventsOn()`` to a
-[supported Set](https://docs.fauna.com/fauna/current/reference/streaming_reference/#sets).
+[supported Set](https://docs.fauna.com/fauna/current/reference/cdc/#sets).
 
 
 To start and subscribe to the stream, pass the event source to ``stream()``:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
* Updates several doc links
* Fixes a minor typo
* Adds some more context to Event Streaming so it better aligns with Event Feeds.

### Motivation and context
We recently updated the doc URLs for CDC features (Event Streaming and Event Feeds). While the previous links still work, this helps users avoid a hop.

The other changes are non-substantial wording changes.

### How was the change tested?
N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


