### PR TITLE
[DOCS-3751] Event Feeds: Document `page_size` limit

### DIFF
--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -83,7 +83,8 @@ class FeedOptions:
     * start_ts - The starting timestamp of the Event Feed, exclusive. If set, Fauna will return events starting after
     the timestamp.
     * cursor - The starting event cursor, exclusive. If set, Fauna will return events starting after the cursor.
-    * page_size - The desired number of events per page.
+    * page_size - Maximum number of events returned per page. Must be in the
+    range 1 to 16000 (inclusive). Defaults to 16.
     """
   max_attempts: Optional[int] = None
   max_backoff: Optional[int] = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
Documents accepted range for `page_size` in `FeedOptions`.

### Motivation and context
Keeps docs updated with changes in https://github.com/fauna/core/pull/12010.

### How was the change tested?
N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


