### PR TITLE
fix: Bump httpx in setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint-tests:
 	python -m yapf -i --recursive tests
 
 run-fauna:
-	docker-compose -f tests/docker-compose-tests.yml up --build faunadb
+	docker compose -f tests/docker-compose-tests.yml up --build faunadb
 
 docker-test:
-	docker-compose -f tests/docker-compose-tests.yml run --rm --build $(PYTHON_VERSION)
+	docker compose -f tests/docker-compose-tests.yml run --rm --build $(PYTHON_VERSION)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# IMPORTANT: update setup.py too
 iso8601==2.1.0
 future==1.0.0
 httpx[http2]==0.28.*

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,17 @@ with open(path.join(local_dir, "README.md"), encoding="utf-8") as f:
 requires = [
     "iso8601==2.1.0",
     "future==1.0.0",
-    "httpx[http2]==0.27.*",
+    "httpx[http2]==0.28.*",
 ]
 
 extras_require = {
     "lint": ["yapf==0.40.1"],
     "test": [
-        "pytest==8.1.1", "pytest-env==1.1.3", "pytest-cov==5.0.0",
-        "pytest-httpx==0.30.0", "pytest-subtests==0.12.1"
+        "pytest==8.1.1",
+        "pytest-env==1.1.3",
+        "pytest-cov==5.0.0",
+        "pytest-httpx==0.35.0",
+        "pytest-subtests==0.12.1",
     ]
 }
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -188,7 +188,7 @@ def test_query_tags(
         json={"data": "mocked"},
     )
 
-  httpx_mock.add_callback(validate_tags)
+  httpx_mock.add_callback(validate_tags, is_reusable=True)
 
   with httpx.Client() as mockClient:
     with subtests.test("should not be set"):
@@ -246,7 +246,7 @@ def test_client_headers(
         json={"data": "mocked"},
     )
 
-  httpx_mock.add_callback(validate_headers)
+  httpx_mock.add_callback(validate_headers, is_reusable=True)
 
   with httpx.Client() as mockClient:
     http_client = HTTPXClient(mockClient)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description

Update `setup.py` with the desired `httpx` versions

### Motivation and context

#206 didn't include updating the `setup.py` 🤦‍♂️ 

### How was the change tested?

N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


