### PR TITLE
docs: Update several feature names to sentence case

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,13 +285,13 @@ for products in pages:
         print(products)
 ```
 
-## Event Feeds
+## Event feeds
 
-The driver supports [Event Feeds](https://docs.fauna.com/fauna/current/learn/cdc/#event-feeds).
+The driver supports [event feeds](https://docs.fauna.com/fauna/current/learn/cdc/#event-feeds).
 
-### Request an Event Feed
+### Request an event feed
 
-An Event Feed asynchronously polls an [event source](https://docs.fauna.com/fauna/current/learn/cdc/#create-an-event-source)
+An event feed asynchronously polls an [event source](https://docs.fauna.com/fauna/current/learn/cdc/#create-an-event-source)
 for paginated events.
 
 To get an event source, append ``eventSource()`` or ``eventsOn()`` to a
@@ -327,7 +327,7 @@ You can also pass a query that produces an event source directly to ``feed()``:
   client.feed(query)
 ```
 
-### Iterate on an Event Feed
+### Iterate on an event feed
 
 ``feed()`` returns an iterator that emits pages of events. You can use a
 generator expression to iterate through the pages:
@@ -364,11 +364,11 @@ Alternatively, you can iterate through events instead of pages with
     ## ...
 ```
 
-The Event Feed iterator stops when there are no more events to poll.
+The event feed iterator stops when there are no more events to poll.
 
 ### Error handling
 
-If a non-retryable error occurs when opening or processing an Event Feed, Fauna
+If a non-retryable error occurs when opening or processing an event feed, Fauna
 raises a ``FaunaException``:
 
 ```python
@@ -422,7 +422,7 @@ processing. For example:
       print('error ocurred with event processing: ', e)
 ```
 
-### Event Feed options
+### Event feed options
 
 The client configuration sets default options for the ``feed()`` method.
 
@@ -441,14 +441,14 @@ options = FeedOptions(
 client.feed(fql('Product.all().eventSource()'), options)
 ```
 
-## Event Streaming
+## Event streams
 
-The driver supports [Event
-Streaming](https://docs.fauna.com/fauna/current/reference/cdc/#event-streaming).
+The driver supports [event
+streams](https://docs.fauna.com/fauna/current/reference/cdc/#event-streaming).
 
 ### Start a stream
 
-An Event Stream lets you consume events from an [event
+An event stream lets you consume events from an [event
 source](https://docs.fauna.com/fauna/current/learn/cdc/#create-an-event-source)
 as a real-time subscription.
 

--- a/fauna/client/client.py
+++ b/fauna/client/client.py
@@ -75,12 +75,12 @@ class StreamOptions:
 @dataclass
 class FeedOptions:
   """
-    A dataclass representing options available for an Event Feed.
+    A dataclass representing options available for an event feed.
 
-    * max_attempts - The maximum number of times to attempt an Event Feed query when a retryable exception is thrown.
+    * max_attempts - The maximum number of times to attempt an event feed query when a retryable exception is thrown.
     * max_backoff - The maximum backoff in seconds for an individual retry.
     * query_timeout - Controls the maximum amount of time Fauna will execute a query before returning a page of events.
-    * start_ts - The starting timestamp of the Event Feed, exclusive. If set, Fauna will return events starting after
+    * start_ts - The starting timestamp of the event feed, exclusive. If set, Fauna will return events starting after
     the timestamp.
     * cursor - The starting event cursor, exclusive. If set, Fauna will return events starting after the cursor.
     * page_size - Maximum number of events returned per page. Must be in the
@@ -468,10 +468,10 @@ class Client:
       opts: FeedOptions = FeedOptions(),
   ) -> "FeedIterator":
     """
-        Opens an Event Feed in Fauna and returns an iterator that consume Fauna events.
+        Opens an event feed in Fauna and returns an iterator that consume Fauna events.
 
         :param source: An EventSource or a Query that returns an EventSource.
-        :param opts: (Optional) Event Feed options.
+        :param opts: (Optional) Event feed options.
 
         :return: a :class:`FeedIterator`
 
@@ -661,7 +661,7 @@ class FeedPage:
 
 
 class FeedIterator:
-  """A class to provide an iterator on top of Event Feed pages."""
+  """A class to provide an iterator on top of event feed pages."""
 
   def __init__(self, http: HTTPClient, headers: Dict[str, str], endpoint: str,
                max_attempts: int, max_backoff: int, opts: FeedOptions,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
We recently aligned with marketing to use sentence case for several feature names, including "event feed" and "event stream." This updates the README docs.

### Motivation and context
Better alignment with marketing and other docs.

### How was the change tested?
N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


